### PR TITLE
feat! solidify rust library

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,15 @@ When the quality type indicator is omitted, no quality values are stored for tha
 
 #### Strand Convention
 
-Strand information is relative to the sequenced molecule and follows the same convention as the MM and ML tags for base modifications in the SAM specification:
+Strand information describes the biology of an annotation feature, not the alignment orientation, and follows the same convention as the MM and ML tags for base modifications in the SAM specification:
 
-- **All coordinates are in read orientation**: Coordinates always refer to positions on the forward strand of the original read sequence (i.e. starting from the leftmost base of the unaligned read).
-- **For reverse-strand annotations (`-`)**: The annotation feature is on the reverse/Crick strand of the DNA molecule; however, coordinates still start from the left of the read sequence on the forward strand.
-- **Strand is independent of alignment**: The strand indicator describes the biology of the feature, not the alignment orientation. If a read aligns to the reverse strand of a reference, the MA tag strand indicators remain unchanged.
+- **Per-annotation property**: Strand is a property of each individual annotation, not of the annotation type. One annotation type may contain annotations on different strands.
+- **All coordinates are in read orientation**: Coordinates always refer to positions on the forward strand of the original read sequence (i.e. starting from the leftmost base of the unaligned read), regardless of the strand a given annotation describes.
+- **Alignment independent**: If a read aligns to the reverse strand of a reference, the MA tag strand indicators remain unchanged.
 
 **Example of strand-specific annotations** on a read of length 10 (where `#` marks the annotated region, `-` marks unannotated positions, and coordinates are 1-based):
 
-This shows CTCF annotations on both the forward strand (start 1 length 4) and reverse strand (start 6 length 3).
+This shows CTCF annotations on both the forward strand (start 1 length 4) and reverse strand (start 6 length 3). They belong to the same logical `ctcf` annotation type — the on-disk format groups them into separate sections by strand.
 
 ```
 MA:Z:10;ctcf+Q:1-4;ctcf-Q:6-3
@@ -103,6 +103,14 @@ Position: 1234567890
 Forward:  ####------
 Reverse:  -----###--
 ```
+
+#### Annotation type uniqueness
+
+Within a single MA tag, an annotation type is uniquely identified by its `name` alone. Strand is a property of individual annotations within the type, and `quality_spec` is a property of the type but is not part of its identity for uniqueness purposes (see below).
+
+The on-disk MA tag format groups annotations by `(name, strand, quality_spec)` into sections for compactness. Producers MAY emit multiple sections sharing the same `name` when the annotations span different strands, e.g. `ctcf+Q:1-4;ctcf-Q:6-3` — these represent the same logical type with strand-split annotations.
+
+Producers MUST NOT emit two sections with the same `name` and conflicting `quality_spec` within one MA tag. Parsers MUST treat repeated `name` sections as the same type and merge their annotations; parsers MUST error on conflicting `quality_spec` for the same `name`.
 
 ### Annotation Data
 

--- a/python/molecular_annotation/__init__.py
+++ b/python/molecular_annotation/__init__.py
@@ -1,9 +1,15 @@
 """Python bindings for molecular annotation tags in SAM/BAM/CRAM files."""
 
 # Re-export from the Rust extension
-from molecular_annotation._molecular_annotation import MolecularAnnotations
+from molecular_annotation._molecular_annotation import Annotation, MolecularAnnotations
 
 # Re-export pysam utilities
 from molecular_annotation.pysam_utils import from_record, to_record, write_to_record
 
-__all__ = ["MolecularAnnotations", "from_record", "to_record", "write_to_record"]
+__all__ = [
+    "Annotation",
+    "MolecularAnnotations",
+    "from_record",
+    "to_record",
+    "write_to_record",
+]

--- a/python/pixi.lock
+++ b/python/pixi.lock
@@ -1,0 +1,1342 @@
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/bioconda/
+    indexes:
+    - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.13.1-py310h2b5ca13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/bioconda/linux-64/pysam-0.24.0-py312hf5ad864_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.47.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - pypi: https://files.pythonhosted.org/packages/55/0f/e7f1ff3a1cabc6c4486a7ee1b0506aedf2f5f8329760ac1f4e8032feef2b/pysam-0.24.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: ./
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.22.2-h207b36a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.20.0-h8f0b9e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.4-h19cb2f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.25-h517ebb2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20250104-pl5321ha958ccf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.5-hcc62823_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h70048d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.0-h8f8c405_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.13.1-py310h655e229_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/bioconda/osx-64/pysam-0.24.0-py312hd391412_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.13-ha9537fe_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.47.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+      - pypi: https://files.pythonhosted.org/packages/14/27/cc422d11961a00bd04aa9a8d9a63683a1083fe2e6a491c285a94998d6751/pysam-0.24.0-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: ./
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.20.0-hd5a2499_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.4-h55c6f16_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.25-hc11a715_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.5-hf6b4638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.0-h1b79a29_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.13.1-py310hc7c2786_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/bioconda/osx-arm64/pysam-0.24.0-py312h12d0683_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.47.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      - pypi: https://files.pythonhosted.org/packages/98/c1/37f2fcccce3f1494147e46ccc04996226defe9ccae8251a9ce61296fa599/pysam-0.24.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: ./
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  build_number: 20
+  sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  md5: a9f577daf3de00bca7c3c76c0ecbd1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 28948
+  timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+  sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
+  md5: d2ffd7602c02f2b316fd921d39876885
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  size: 260182
+  timestamp: 1771350215188
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
+  sha256: 9f242f13537ef1ce195f93f0cc162965d6cc79da578568d6d8e50f70dd025c42
+  md5: 4173ac3b19ec0a4f400b4f782910368b
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  size: 133427
+  timestamp: 1771350680709
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+  sha256: 540fe54be35fac0c17feefbdc3e29725cce05d7367ffedfaaa1bdda234b019df
+  md5: 620b85a3f45526a8bc4d23fd78fc22f0
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  size: 124834
+  timestamp: 1771350416561
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+  sha256: cc9accf72fa028d31c2a038460787751127317dcfa991f8d1f1babf216bb454e
+  md5: 920bb03579f15389b9e512095ad995b7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 207882
+  timestamp: 1765214722852
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
+  sha256: 2f5bc0292d595399df0d168355b4e9820affc8036792d6984bd751fdda2bcaea
+  md5: fc9a153c57c9f070bebaa7eef30a8f17
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 186122
+  timestamp: 1765215100384
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
+  sha256: 2995f2aed4e53725e5efbc28199b46bf311c3cab2648fc4f10c2227d6d5fa196
+  md5: bcb3cba70cf1eec964a03b4ba7775f01
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 180327
+  timestamp: 1765215064054
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+  sha256: c9dbcc8039a52023660d6d1bbf87594a93dd69c6ac5a2a44323af2c92976728d
+  md5: e18ad67cf881dcadee8b8d9e2f8e5f73
+  depends:
+  - __unix
+  license: ISC
+  purls: []
+  size: 131039
+  timestamp: 1776865545798
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
+  md5: 962b9857ee8e7018c22f2776ffa0b2d7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/colorama?source=hash-mapping
+  size: 27011
+  timestamp: 1733218222191
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+  sha256: ee6cf346d017d954255bbcbdb424cddea4d14e4ed7e9813e429db1d795d01144
+  md5: 8e662bd460bda79b1ea39194e3c4c9ab
+  depends:
+  - python >=3.10
+  - typing_extensions >=4.6.0
+  license: MIT and PSF-2.0
+  purls:
+  - pkg:pypi/exceptiongroup?source=hash-mapping
+  size: 21333
+  timestamp: 1763918099466
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+  sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
+  md5: c80d8a3b84358cb967fa81e7075fbc8a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 12723451
+  timestamp: 1773822285671
+- conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
+  sha256: 1294117122d55246bb83ad5b589e2a031aacdf2d0b1f99fd338aa4394f881735
+  md5: 627eca44e62e2b665eeec57a984a7f00
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 12273764
+  timestamp: 1773822733780
+- conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+  sha256: e1a9e3b1c8fe62dc3932a616c284b5d8cbe3124bbfbedcf4ce5c828cb166ee19
+  md5: 9614359868482abba1bd15ce465e3c42
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/iniconfig?source=compressed-mapping
+  size: 13387
+  timestamp: 1760831448842
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+  sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
+  md5: b38117a3c920364aff79f870c984b4a3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 134088
+  timestamp: 1754905959823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+  sha256: 3e307628ca3527448dd1cb14ad7bb9d04d1d28c7d4c5f97ba196ae984571dd25
+  md5: fb53fb07ce46a575c5d004bbc96032c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - keyutils >=1.6.3,<2.0a0
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.5,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1386730
+  timestamp: 1769769569681
+- conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.22.2-h207b36a_0.conda
+  sha256: df009385e8262c234c0dae9016540b86dad3d299f0d9366d08e327e8e7731634
+  md5: e66e2c52d2fdddcf314ad750fb4ebb4a
+  depends:
+  - __osx >=10.13
+  - libcxx >=19
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - openssl >=3.5.5,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1193620
+  timestamp: 1769770267475
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
+  sha256: c0a0bf028fe7f3defcdcaa464e536cf1b202d07451e18ad83fdd169d15bef6ed
+  md5: e446e1822f4da8e5080a9de93474184d
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - openssl >=3.5.5,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1160828
+  timestamp: 1769770119811
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+  sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
+  md5: 18335a698559cdbcd86150a48bf54ba6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-64 2.45.1
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 728002
+  timestamp: 1774197446916
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
+  sha256: 75963a5dd913311f59a35dbd307592f4fa754c4808aff9c33edb430c415e38eb
+  md5: c3cc2864f82a944bc90a7beb4d3b0e88
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libnghttp2 >=1.68.1,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  size: 468706
+  timestamp: 1777461492876
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.20.0-h8f0b9e4_0.conda
+  sha256: 5d3d8a82ca43347e96f1d79048921f3a7c25e32514bc7feb53ed2a040dcca54d
+  md5: 4a0085ccf90dc514f0fc0909a874045e
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libnghttp2 >=1.68.1,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  size: 419676
+  timestamp: 1777462238769
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.20.0-hd5a2499_0.conda
+  sha256: 38c0bc634b61e542776e97cfd15d5d41edd304d4e47c333004d2d622439b2381
+  md5: 2f57b7d0c6adda88957586b7afd78438
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libnghttp2 >=1.68.1,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  size: 400568
+  timestamp: 1777462251987
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.4-h19cb2f5_0.conda
+  sha256: 596a0bdd5321c5e41a4734f18b35bcbc5d116079d13bc40d765fd93c32b285d1
+  md5: 4394b1ba4b9604ac4e1c5bdc74451279
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 567125
+  timestamp: 1776815441323
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.4-h55c6f16_0.conda
+  sha256: 25a0d02148a39b665d9c2957676faf62a4d2a58494d53b201151199a197db4b0
+  md5: 448a1af83a9205655ee1cf48d3875ca3
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 569927
+  timestamp: 1776816293111
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+  sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
+  md5: 6c77a605a7a689d17d4819c0f8ac9a00
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 73490
+  timestamp: 1761979956660
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.25-h517ebb2_0.conda
+  sha256: 025f8b1e85dd8254e0ca65f011919fb1753070eb507f03bca317871a884d24de
+  md5: 31aa65919a729dc48180893f62c25221
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 70840
+  timestamp: 1761980008502
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.25-hc11a715_0.conda
+  sha256: 5e0b6961be3304a5f027a8c00bd0967fc46ae162cffb7553ff45c70f51b8314c
+  md5: a6130c709305cd9828b4e1bd9ba0000c
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 55420
+  timestamp: 1761980066242
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+  sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
+  md5: c277e0a4d549b03ac1e9d6cbbe3d017b
+  depends:
+  - ncurses
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 134676
+  timestamp: 1738479519902
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20250104-pl5321ha958ccf_0.conda
+  sha256: 6cc49785940a99e6a6b8c6edbb15f44c2dd6c789d9c283e5ee7bdfedd50b4cd6
+  md5: 1f4ed31220402fcddc083b4bff406868
+  depends:
+  - ncurses
+  - __osx >=10.13
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 115563
+  timestamp: 1738479554273
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+  sha256: 66aa216a403de0bb0c1340a88d1a06adaff66bae2cfd196731aa24db9859d631
+  md5: 44083d2d2c2025afca315c7a172eab2b
+  depends:
+  - ncurses
+  - __osx >=11.0
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 107691
+  timestamp: 1738479560845
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 112766
+  timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
+  md5: 899db79329439820b7e8f8de41bca902
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 106663
+  timestamp: 1702146352558
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 107458
+  timestamp: 1702146414478
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
+  sha256: e8c2b57f6aacabdf2f1b0924bd4831ce5071ba080baa4a9e8c0d720588b6794c
+  md5: 49f570f3bc4c874a06ea69b7225753af
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.7.5.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 76624
+  timestamp: 1774719175983
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.5-hcc62823_0.conda
+  sha256: 341d8a457a8342c396a8ac788da2639cbc8b62568f6ba2a3d322d1ace5aa9e16
+  md5: 1d6e71b8c73711e28ffe207acdc4e2f8
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.7.5.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 74797
+  timestamp: 1774719557730
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.5-hf6b4638_0.conda
+  sha256: 06780dec91dd25770c8cf01e158e1062fbf7c576b1406427475ce69a8af75b7e
+  md5: a32123f93e168eaa4080d87b0fb5da8a
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.7.5.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 68192
+  timestamp: 1774719211725
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+  sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
+  md5: a360c33a5abe61c07959e449fa1453eb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 58592
+  timestamp: 1769456073053
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
+  sha256: 951958d1792238006fdc6fce7f71f1b559534743b26cc1333497d46e5903a2d6
+  md5: 66a0dc7464927d0853b590b6f53ba3ea
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 53583
+  timestamp: 1769456300951
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+  sha256: 6686a26466a527585e6a75cc2a242bf4a3d97d6d6c86424a441677917f28bec7
+  md5: 43c04d9cb46ef176bb2a4c77e324d599
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 40979
+  timestamp: 1769456747661
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
+  sha256: faf7d2017b4d718951e3a59d081eb09759152f93038479b768e3d612688f83f5
+  md5: 0aa00f03f9e39fb9876085dee11a85d4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.2.0=*_18
+  - libgomp 15.2.0 he0feb66_18
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 1041788
+  timestamp: 1771378212382
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
+  sha256: e318a711400f536c81123e753d4c797a821021fb38970cebfb3f454126016893
+  md5: d5e96b1ed75ca01906b3d2469b4ce493
+  depends:
+  - libgcc 15.2.0 he0feb66_18
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 27526
+  timestamp: 1771378224552
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
+  sha256: 21337ab58e5e0649d869ab168d4e609b033509de22521de1bfed0c031bfc5110
+  md5: 239c5e9546c38a1e884d69effcf4c882
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 603262
+  timestamp: 1771378117851
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+  sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
+  md5: b88d90cad08e6bc8ad540cb310a761fb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  purls: []
+  size: 113478
+  timestamp: 1775825492909
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
+  sha256: d9e2006051529aec5578c6efeb13bb6a7200a014b2d5a77a579e83a8049d5f3c
+  md5: becdfbfe7049fa248e52aa37a9df09e2
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  purls: []
+  size: 105724
+  timestamp: 1775826029494
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+  sha256: 34878d87275c298f1a732c6806349125cebbf340d24c6c23727268184bba051e
+  md5: b1fd823b5ae54fbec272cea0811bd8a9
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  purls: []
+  size: 92472
+  timestamp: 1775825802659
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+  sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
+  md5: 2a45e7f8af083626f009645a6481f12d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.34.6,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 663344
+  timestamp: 1773854035739
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h70048d4_0.conda
+  sha256: 899551e16aac9dfb85bfc2fd98b655f4d1b7fea45720ec04ccb93d95b4d24798
+  md5: dba4c95e2fe24adcae4b77ebf33559ae
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.6,<2.0a0
+  - libcxx >=19
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 606749
+  timestamp: 1773854765508
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
+  sha256: 2bc7bc3978066f2c274ebcbf711850cc9ab92e023e433b9631958a098d11e10a
+  md5: 6ea18834adbc3b33df9bd9fb45eaf95b
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.6,<2.0a0
+  - libcxx >=19
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 576526
+  timestamp: 1773854624224
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+  sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
+  md5: d864d34357c3b65a4b731f78c0801dc4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-only
+  license_family: GPL
+  purls: []
+  size: 33731
+  timestamp: 1750274110928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
+  sha256: ec37c79f737933bbac965f5dc0f08ef2790247129a84bb3114fad4900adce401
+  md5: 810d83373448da85c3f673fbcb7ad3a3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  purls: []
+  size: 958864
+  timestamp: 1775753750179
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.0-h8f8c405_0.conda
+  sha256: ae9d83cab8988a7d4ccec411fef23c141b5b3d301db3e926ab7cd4befe3764e6
+  md5: f2bb6692dfb33a1bbce746aa812a9a5b
+  depends:
+  - __osx >=11.0
+  - icu >=78.3,<79.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  purls: []
+  size: 1007272
+  timestamp: 1775754456682
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.0-h1b79a29_0.conda
+  sha256: 1a9d1e3e18dbb0b87cff3b40c3e42703730d7ac7ee9b9322c2682196a81ba0c3
+  md5: 8423c008105df35485e184066cad4566
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  purls: []
+  size: 920039
+  timestamp: 1775754485962
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+  sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
+  md5: eecce068c7e4eddeb169591baac20ac4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 304790
+  timestamp: 1745608545575
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
+  sha256: 00654ba9e5f73aa1f75c1f69db34a19029e970a4aeb0fa8615934d8e9c369c3c
+  md5: a6cb15db1c2dc4d3a5f6cf3772e09e81
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 284216
+  timestamp: 1745608575796
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
+  sha256: 8bfe837221390ffc6f111ecca24fa12d4a6325da0c8d131333d63d6c37f27e0a
+  md5: b68e8f66b94b44aaa8de4583d3d4cc40
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 279193
+  timestamp: 1745608793272
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
+  sha256: 78668020064fdaa27e9ab65cd2997e2c837b564ab26ce3bf0e58a2ce1a525c6e
+  md5: 1b08cd684f34175e4514474793d44bcb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.2.0 he0feb66_18
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_18
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 5852330
+  timestamp: 1771378262446
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
+  sha256: bc1b08c92626c91500fd9f26f2c797f3eb153b627d53e9c13cd167f1e12b2829
+  md5: 38ffe67b78c9d4de527be8315e5ada2c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 40297
+  timestamp: 1775052476770
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 100393
+  timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
+  md5: d87ff7921124eccd67248aa483c23fec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 63629
+  timestamp: 1774072609062
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
+  sha256: 4c6da089952b2d70150c74234679d6f7ac04f4a98f9432dec724968f912691e7
+  md5: 30439ff30578e504ee5e0b390afc8c65
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 59000
+  timestamp: 1774073052242
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+  sha256: 361415a698514b19a852f5d1123c5da746d4642139904156ddfca7c922d23a05
+  md5: bc5a5721b6439f2f62a84f2548136082
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 47759
+  timestamp: 1774072956767
+- conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.13.1-py310h2b5ca13_0.conda
+  noarch: python
+  sha256: ff51099c31fcb1c4a42b2544243f9289e759b4e3f578a1f64652f26626c2f938
+  md5: e1d2e0dd76c196b48e34b61ef5b65e9b
+  depends:
+  - python
+  - tomli >=1.1.0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - openssl >=3.5.6,<4.0a0
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=hash-mapping
+  size: 8938226
+  timestamp: 1775757052305
+- conda: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.13.1-py310h655e229_0.conda
+  noarch: python
+  sha256: 4eb0fae84d086d94d45baf2168c9242b4943fa2c121c6a8d3c0b354619e70b27
+  md5: 0fe3a16db8d427affaa4a3444fe49a53
+  depends:
+  - python
+  - tomli >=1.1.0
+  - __osx >=11.0
+  - openssl >=3.5.6,<4.0a0
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=hash-mapping
+  size: 8535580
+  timestamp: 1775757198049
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.13.1-py310hc7c2786_0.conda
+  noarch: python
+  sha256: 223df8782bfe0d59924c1430e6715eda38a361f37b434f737443b9b9e9b9c746
+  md5: 71eb5c18a03cf3a262c0a695920cfeed
+  depends:
+  - python
+  - tomli >=1.1.0
+  - __osx >=11.0
+  - openssl >=3.5.6,<4.0a0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=hash-mapping
+  size: 8062956
+  timestamp: 1775757236606
+- pypi: ./
+  name: molecular-annotation
+  version: 0.1.0
+  sha256: 35c105adbdebe3d3d91eee204d07699e660cbf903dc939843da7e336d95378c8
+  requires_dist:
+  - pysam>=0.20
+  - pytest>=7.0 ; extra == 'dev'
+  requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+  sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
+  md5: fc21868a1a5aacc937e7a18747acb8a5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: X11 AND BSD-3-Clause
+  purls: []
+  size: 918956
+  timestamp: 1777422145199
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
+  sha256: f5f7e006ff4271305ab4cc08eedd855c67a571793c3d18aff73f645f088a8cae
+  md5: 31b8740cf1b2588d4e61c81191004061
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  purls: []
+  size: 831711
+  timestamp: 1777423052277
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+  sha256: 4ea6c620b87bd1d42bb2ccc2c87cd2483fa2d7f9e905b14c223f11ff3f4c455d
+  md5: 343d10ed5b44030a2f67193905aea159
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  purls: []
+  size: 805509
+  timestamp: 1777423252320
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+  sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
+  md5: da1b85b6a87e141f5140bb9924cecab0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 3167099
+  timestamp: 1775587756857
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
+  sha256: 334fd49ea31b99114f5afb1ec44555dc8c90640648302a4f8f838ee345d1ec50
+  md5: 5cf0ece4375c73d7a5765e83565a69c7
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 2776564
+  timestamp: 1775589970694
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
+  sha256: c91bf510c130a1ea1b6ff023e28bac0ccaef869446acd805e2016f69ebdc49ea
+  md5: 25dcccd4f80f1638428613e0d7c9b4e1
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 3106008
+  timestamp: 1775587972483
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
+  md5: 4c06a92e74452cfa53623a81592e8934
+  depends:
+  - python >=3.8
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/packaging?source=compressed-mapping
+  size: 91574
+  timestamp: 1777103621679
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
+  sha256: 8e1497814a9997654ed7990a79c054ea5a42545679407acbc6f7e809c73c9120
+  md5: 67bdec43082fd8a9cffb9484420b39a2
+  depends:
+  - python >=3.10,<3.13.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pip?source=compressed-mapping
+  size: 1181790
+  timestamp: 1770270305795
+- conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  sha256: e14aafa63efa0528ca99ba568eaf506eb55a0371d12e6250aaaa61718d2eb62e
+  md5: d7585b6550ad04c8c5e21097ada2888e
+  depends:
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pluggy?source=hash-mapping
+  size: 25877
+  timestamp: 1764896838868
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+  sha256: cf70b2f5ad9ae472b71235e5c8a736c9316df3705746de419b59d442e8348e86
+  md5: 16c18772b340887160c79a6acc022db0
+  depends:
+  - python >=3.10
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pygments?source=compressed-mapping
+  size: 893031
+  timestamp: 1774796815820
+- pypi: https://files.pythonhosted.org/packages/14/27/cc422d11961a00bd04aa9a8d9a63683a1083fe2e6a491c285a94998d6751/pysam-0.24.0-cp312-cp312-macosx_10_13_x86_64.whl
+  name: pysam
+  version: 0.24.0
+  sha256: 38d5cc5dff4bdaceabbb58c0700c41b132aacf783432b1d16060b46ac7d866e2
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/55/0f/e7f1ff3a1cabc6c4486a7ee1b0506aedf2f5f8329760ac1f4e8032feef2b/pysam-0.24.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: pysam
+  version: 0.24.0
+  sha256: 4a642f18649e59817de272173e9c27c031dceaca199809e4f8b338ebfc5d6698
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/98/c1/37f2fcccce3f1494147e46ccc04996226defe9ccae8251a9ce61296fa599/pysam-0.24.0-cp312-cp312-macosx_11_0_arm64.whl
+  name: pysam
+  version: 0.24.0
+  sha256: 4da222cf6887b272c09351381efa20bfc96e0a47a944a822785fc5b6bc8b8c9d
+  requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/bioconda/linux-64/pysam-0.24.0-py312hf5ad864_0.conda
+  sha256: 2ca1a2f1f41e6ecebdb91810d19a90062a43cc77f63624f2a3ba48c6b3fe6431
+  md5: 60da61a7b109d39c78ecef7dc0d574b1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.19.0,<9.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  size: 3940274
+  timestamp: 1777326341973
+- conda: https://conda.anaconda.org/bioconda/osx-64/pysam-0.24.0-py312hd391412_0.conda
+  sha256: e672214e85e0206aec24e161d7feda095a4f3eaca6a514ef38e37a2c6c460eb9
+  md5: 599a575255d55ac8d7efc3cf19d8b98d
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.19.0,<9.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  size: 3606239
+  timestamp: 1777330111790
+- conda: https://conda.anaconda.org/bioconda/osx-arm64/pysam-0.24.0-py312h12d0683_0.conda
+  sha256: c1ac1accb52bbcf9fb1a4809450abf7b47396b40d0b6df92968f380cdf062772
+  md5: f5b768b6afcfa0f14e8b699f0b9dbac3
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.19.0,<9.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  size: 3531815
+  timestamp: 1777325836305
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+  sha256: 960f59442173eee0731906a9077bd5ccf60f4b4226f05a22d1728ab9a21a879c
+  md5: 6a991452eadf2771952f39d43615bb3e
+  depends:
+  - colorama >=0.4
+  - pygments >=2.7.2
+  - python >=3.10
+  - iniconfig >=1.0.1
+  - packaging >=22
+  - pluggy >=1.5,<2
+  - tomli >=1
+  - exceptiongroup >=1
+  - python
+  constrains:
+  - pytest-faulthandler >=2
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pytest?source=compressed-mapping
+  size: 299984
+  timestamp: 1775644472530
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
+  sha256: a44655c1c3e1d43ed8704890a91e12afd68130414ea2c0872e154e5633a13d7e
+  md5: 7eccb41177e15cc672e1babe9056018e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.7.4,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - liblzma >=5.8.2,<6.0a0
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.51.2,<4.0a0
+  - libuuid >=2.41.3,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.5,<4.0a0
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  size: 31608571
+  timestamp: 1772730708989
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.13-ha9537fe_0_cpython.conda
+  sha256: fb592ceb1bc247d19247d5535083da4a79721553e29e1290f5d81c07d4f086b5
+  md5: ec05996c0d914a4e98ee3c7d789083f8
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.4,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - liblzma >=5.8.2,<6.0a0
+  - libsqlite >=3.51.2,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.5,<4.0a0
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  size: 13672169
+  timestamp: 1772730464626
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
+  sha256: e658e647a4a15981573d6018928dec2c448b10c77c557c29872043ff23c0eb6a
+  md5: 8e7608172fa4d1b90de9a745c2fd2b81
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.4,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - liblzma >=5.8.2,<6.0a0
+  - libsqlite >=3.51.2,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.5,<4.0a0
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  size: 12127424
+  timestamp: 1772730755512
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+  build_number: 8
+  sha256: 80677180dd3c22deb7426ca89d6203f1c7f1f256f2d5a94dc210f6e758229809
+  md5: c3efd25ac4d74b1584d2f7a57195ddf1
+  constrains:
+  - python 3.12.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 6958
+  timestamp: 1752805918820
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+  sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
+  md5: d7d95fc8287ea7bf33e0e7116d2b95ec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 345073
+  timestamp: 1765813471974
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
+  sha256: 4614af680aa0920e82b953fece85a03007e0719c3399f13d7de64176874b80d5
+  md5: eefd65452dfe7cce476a519bece46704
+  depends:
+  - __osx >=10.13
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 317819
+  timestamp: 1765813692798
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+  sha256: a77010528efb4b548ac2a4484eaf7e1c3907f2aec86123ed9c5212ae44502477
+  md5: f8381319127120ce51e081dce4865cf4
+  depends:
+  - __osx >=11.0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 313930
+  timestamp: 1765813902568
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+  sha256: 82088a6e4daa33329a30bc26dc19a98c7c1d3f05c0f73ce9845d4eab4924e9e1
+  md5: 8e194e7b992f99a5015edbd4ebd38efd
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/setuptools?source=hash-mapping
+  size: 639697
+  timestamp: 1773074868565
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+  sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
+  md5: cffd3bdd58090148f4cfcd831f4b26ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: TCL
+  license_family: BSD
+  purls: []
+  size: 3301196
+  timestamp: 1769460227866
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
+  sha256: 7f0d9c320288532873e2d8486c331ec6d87919c9028208d3f6ac91dc8f99a67b
+  md5: 6e6efb7463f8cef69dbcb4c2205bf60e
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  purls: []
+  size: 3282953
+  timestamp: 1769460532442
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+  sha256: 799cab4b6cde62f91f750149995d149bc9db525ec12595e8a1d91b9317f038b3
+  md5: a9d86bc62f39b94c4661716624eb21b0
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  purls: []
+  size: 3127137
+  timestamp: 1769460817696
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
+  md5: b5325cf06a000c5b14970462ff5e4d58
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/tomli?source=hash-mapping
+  size: 21561
+  timestamp: 1774492402955
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+  sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
+  md5: 0caa1af407ecff61170c9437a808404d
+  depends:
+  - python >=3.10
+  - python
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/typing-extensions?source=hash-mapping
+  size: 51692
+  timestamp: 1756220668932
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
+  md5: ad659d0a2b3e47e38d829aa8cad2d610
+  license: LicenseRef-Public-Domain
+  purls: []
+  size: 119135
+  timestamp: 1767016325805
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.47.0-pyhd8ed1ab_0.conda
+  sha256: 9e156ffaefb8463437144326ada4b85d1de17961b9997ac5f1cbbaf747bd8bed
+  md5: d0e3b2f0030cf4fca58bde71d246e94c
+  depends:
+  - packaging >=24.0
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/wheel?source=compressed-mapping
+  size: 33491
+  timestamp: 1776878563806
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
+  md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 601375
+  timestamp: 1764777111296
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+  sha256: 47101a4055a70a4876ffc87b750ab2287b67eca793f21c8224be5e1ee6394d3f
+  md5: 727109b184d680772e3122f40136d5ca
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 528148
+  timestamp: 1764777156963
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+  sha256: 9485ba49e8f47d2b597dd399e88f4802e100851b27c21d7525625b0b4025a5d9
+  md5: ab136e4c34e97f34fb621d2592a393d8
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 433413
+  timestamp: 1764777166076

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -50,3 +50,30 @@ module-name = "molecular_annotation._molecular_annotation"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+# ---------------------------------------------------------------------------
+# Pixi configuration (see https://pixi.sh)
+# Run from `python/`:
+#   pixi run build   # maturin develop into the pixi env
+#   pixi run test    # build + pytest
+# ---------------------------------------------------------------------------
+
+[tool.pixi.workspace]
+name = "molecular-annotation-py"
+channels = ["conda-forge", "bioconda"]
+platforms = ["osx-arm64", "osx-64", "linux-64"]
+
+[tool.pixi.dependencies]
+python = ">=3.10,<3.13"
+maturin = ">=1.1,<2"
+pip = "*"
+pytest = ">=7"
+pysam = ">=0.20"
+
+[tool.pixi.pypi-dependencies]
+molecular-annotation = { path = ".", editable = true }
+
+[tool.pixi.tasks]
+build = "maturin develop --release"
+test = { cmd = "pytest tests/ -v", depends-on = ["build"] }
+test-fast = "pytest tests/ -v"

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -40,10 +40,67 @@ use pyo3::prelude::*;
 
 // Use fully qualified path to avoid name collision with the pymodule
 use ::molecular_annotation::{
+    Annotation as RustAnnotation,
     MolecularAnnotations as RustMolecularAnnotations,
     QualitySpec as RustQualitySpec,
     Strand as RustStrand,
 };
+
+/// A single molecular annotation (read-only snapshot).
+///
+/// Passed to the predicate of `MolecularAnnotations.retain`. All coordinates
+/// are 0-based half-open `[start, end)` in the original molecular orientation.
+#[pyclass(name = "Annotation", frozen)]
+#[derive(Clone)]
+pub struct Annotation {
+    /// 0-based start position (inclusive), in molecular orientation.
+    #[pyo3(get)]
+    pub start: u32,
+    /// Length in base pairs.
+    #[pyo3(get)]
+    pub length: u32,
+    strand_char: char,
+    /// Quality scores (one per quality spec character; empty if type has no quality).
+    #[pyo3(get)]
+    pub qualities: Vec<u8>,
+    /// Optional name/label for this annotation.
+    #[pyo3(get)]
+    pub name: Option<String>,
+}
+
+impl Annotation {
+    fn from_rust(a: &RustAnnotation) -> Self {
+        Self {
+            start: a.start,
+            length: a.length,
+            strand_char: a.strand.as_char(),
+            qualities: a.qualities.clone(),
+            name: a.name.clone(),
+        }
+    }
+}
+
+#[pymethods]
+impl Annotation {
+    /// End position (0-based, exclusive). Saturates at u32::MAX on overflow.
+    #[getter]
+    fn end(&self) -> u32 {
+        self.start.saturating_add(self.length)
+    }
+
+    /// Strand as a single-character string: "+", "-", or ".".
+    #[getter]
+    fn strand(&self) -> String {
+        self.strand_char.to_string()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Annotation(start={}, length={}, strand='{}', qualities={:?}, name={:?})",
+            self.start, self.length, self.strand_char, self.qualities, self.name
+        )
+    }
+}
 
 /// Container for all molecular annotations on a read.
 ///
@@ -340,6 +397,59 @@ impl MolecularAnnotations {
         Ok(())
     }
 
+    /// Retain only the annotations of `type_name` for which `predicate` returns True.
+    ///
+    /// The predicate is called once per annotation with an `Annotation` snapshot
+    /// (read-only view of `start`, `length`, `end`, `strand`, `qualities`, `name`).
+    /// Annotations for which it returns False are removed. If `type_name` does
+    /// not exist, this is a no-op. The type itself is left in place even if
+    /// all of its annotations are dropped (matches the Rust API and the
+    /// empty-type emission behavior — an empty type does not appear in the MA tag).
+    ///
+    /// Args:
+    ///     type_name: Name of the annotation type to filter.
+    ///     predicate: Callable taking an Annotation and returning bool.
+    ///
+    /// Raises:
+    ///     Propagates any exception raised by `predicate`. The first error
+    ///     short-circuits the filter; subsequent annotations are left in place.
+    ///
+    /// Example:
+    ///     >>> annot.retain("msp", lambda a: a.length >= 50)
+    ///     >>> annot.retain("msp", lambda a: a.qualities and a.qualities[0] >= 40)
+    ///     >>> annot.retain("msp", lambda a: 50 <= a.length < 100)
+    pub fn retain(
+        &mut self,
+        py: Python<'_>,
+        type_name: &str,
+        predicate: PyObject,
+    ) -> PyResult<()> {
+        let mut err: Option<PyErr> = None;
+        self.inner.retain(type_name, |a| {
+            if err.is_some() {
+                return true;
+            }
+            let snapshot = Annotation::from_rust(a);
+            match predicate.call1(py, (snapshot,)) {
+                Ok(result) => match result.extract::<bool>(py) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        err = Some(e);
+                        true
+                    }
+                },
+                Err(e) => {
+                    err = Some(e);
+                    true
+                }
+            }
+        });
+        if let Some(e) = err {
+            return Err(e);
+        }
+        Ok(())
+    }
+
     /// Get coordinates in BAM orientation.
     ///
     /// Returns 0-based half-open [start, end) intervals. For reverse-aligned
@@ -596,5 +706,6 @@ impl MolecularAnnotations {
 #[pymodule]
 fn _molecular_annotation(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<MolecularAnnotations>()?;
+    m.add_class::<Annotation>()?;
     Ok(())
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -203,9 +203,16 @@ impl MolecularAnnotations {
     ///
     /// Accepts 0-based half-open intervals [start, end).
     ///
+    /// Annotation type identity is keyed on `type_name` alone — strand is a
+    /// per-annotation property. Multiple `add_annotations` calls with the
+    /// same `type_name` and matching `quality_spec` accumulate into a single
+    /// in-memory type, even when their `strand` values differ. Conflicting
+    /// `quality_spec` for the same `type_name` raises ValueError.
+    ///
     /// Args:
     ///     type_name: Name of the annotation type (e.g., "msp", "nuc", "fire")
-    ///     strand: Strand orientation: "+" (forward), "-" (reverse), or "." (unknown)
+    ///     strand: Strand applied to every annotation in this batch:
+    ///         "+" (forward), "-" (reverse), or "." (unknown).
     ///     quality_spec: Quality specification string. Each character is "P" (Phred) or
     ///         "Q" (Linear). The length determines how many quality values per annotation.
     ///         Examples: "P" (one phred), "PQ" (two: phred + linear), "" (none).
@@ -219,7 +226,8 @@ impl MolecularAnnotations {
     ///
     /// Raises:
     ///     ValueError: If array lengths don't match, both ends and lengths are provided,
-    ///         neither ends nor lengths are provided, or strand/quality_spec is invalid.
+    ///         neither ends nor lengths are provided, strand/quality_spec is invalid,
+    ///         or the type already exists with a different quality_spec.
     ///
     /// Example:
     ///     >>> annot = MolecularAnnotations(1000)
@@ -229,6 +237,9 @@ impl MolecularAnnotations {
     ///     >>> annot.add_annotations("ctcf", "+", "PQ", [100, 200], lengths=[50, 60], qualities=[40, 255, 30, 200])
     ///     >>> # No quality
     ///     >>> annot.add_annotations("nuc", "+", "", [100, 200], lengths=[50, 60])
+    ///     >>> # Mixed-strand annotations of the same type — accumulate into one type
+    ///     >>> annot.add_annotations("ctcf", "+", "Q", [10], lengths=[4], qualities=[200])
+    ///     >>> annot.add_annotations("ctcf", "-", "Q", [50], lengths=[3], qualities=[180])
     #[pyo3(signature = (type_name, strand, quality_spec, starts, ends=None, lengths=None, qualities=None, names=None))]
     pub fn add_annotations(
         &mut self,
@@ -259,7 +270,6 @@ impl MolecularAnnotations {
                         format!("starts and ends must have same length ({} vs {})", starts.len(), ends.len())
                     ));
                 }
-                // Validate and convert ends to lengths
                 let mut lens = Vec::with_capacity(starts.len());
                 for i in 0..starts.len() {
                     let start = starts[i];
@@ -279,7 +289,6 @@ impl MolecularAnnotations {
                         format!("starts and lengths must have same length ({} vs {})", starts.len(), lengths.len())
                     ));
                 }
-                // Validate lengths are positive (u32 can't be negative, but check for zero)
                 for (i, &len) in lengths.iter().enumerate() {
                     if len == 0 {
                         return Err(pyo3::exceptions::PyValueError::new_err(
@@ -293,8 +302,10 @@ impl MolecularAnnotations {
 
         let strand = parse_strand(strand)?;
         let qs = parse_quality_spec(quality_spec)?;
-        let num_q = qs.num_qualities();
 
+        // qualities/names length validation (matches Rust add_annotations,
+        // but we do it here to keep the Python error messages descriptive)
+        let num_q = qs.num_qualities();
         if let Some(ref q) = qualities {
             let expected = starts.len() * num_q;
             if q.len() != expected {
@@ -306,7 +317,6 @@ impl MolecularAnnotations {
                 ));
             }
         }
-
         if let Some(ref n) = names {
             if n.len() != starts.len() {
                 return Err(pyo3::exceptions::PyValueError::new_err(
@@ -315,36 +325,17 @@ impl MolecularAnnotations {
             }
         }
 
-        // Find or create the annotation type
-        let at = if let Some(existing) = self.inner.get_type_mut(type_name) {
-            // Verify strand and quality spec match
-            if existing.strand != strand || existing.quality_spec != qs {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    format!(
-                        "Annotation type '{}' already exists with different configuration: \
-                        existing='{}{}', attempted='{}{}'",
-                        type_name, existing.strand, existing.quality_spec, strand, qs
-                    )
-                ));
-            }
-            existing
-        } else {
-            self.inner.add_annotation_type(type_name, strand, qs)
-        };
-
-        // Add all annotations
-        for i in 0..starts.len() {
-            let q = if num_q > 0 {
-                qualities
-                    .as_ref()
-                    .map(|qs| qs[i * num_q..(i + 1) * num_q].to_vec())
-                    .unwrap_or_default()
-            } else {
-                Vec::new()
-            };
-            let name = names.as_ref().map(|n| n[i].clone());
-            at.add(starts[i], computed_lengths[i], q, name);
-        }
+        self.inner
+            .add_annotations(
+                type_name,
+                qs,
+                &starts,
+                &computed_lengths,
+                strand,
+                qualities.as_deref(),
+                names.as_deref(),
+            )
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
         Ok(())
     }

--- a/python/tests/test_molecular_annotation.py
+++ b/python/tests/test_molecular_annotation.py
@@ -1,7 +1,12 @@
 """Tests for the molecular_annotation Python bindings."""
 
 import pytest
-from molecular_annotation import MolecularAnnotations, from_record, write_to_record
+from molecular_annotation import (
+    Annotation,
+    MolecularAnnotations,
+    from_record,
+    write_to_record,
+)
 
 
 class TestMolecularAnnotations:
@@ -403,3 +408,154 @@ class TestPysamIntegration:
 
         with pytest.raises(KeyError):
             from_record(record)
+
+
+class TestRetain:
+    """Tests for MolecularAnnotations.retain (mirrors rust/src/tests.rs)."""
+
+    def test_retain_filters_by_length(self):
+        annotations = MolecularAnnotations(1000)
+        annotations.add_annotations(
+            "msp",
+            "+",
+            "P",
+            starts=[100, 200, 300],
+            lengths=[50, 60, 70],
+            qualities=[40, 35, 30],
+        )
+
+        annotations.retain("msp", lambda a: a.length > 55)
+
+        items = annotations.iter_type("msp")
+        assert items is not None
+        assert len(items) == 2
+        # iter_type tuple: (q_start, q_end, f_start, f_end, r_start, r_end, quals, name)
+        assert items[0][3] - items[0][2] == 60
+        assert items[1][3] - items[1][2] == 70
+
+    def test_retain_filters_by_quality(self):
+        annotations = MolecularAnnotations(1000)
+        annotations.add_annotations(
+            "msp",
+            "+",
+            "P",
+            starts=[100, 200, 300],
+            lengths=[50, 60, 70],
+            qualities=[40, 10, 200],
+        )
+
+        annotations.retain("msp", lambda a: a.qualities[0] >= 40)
+
+        items = annotations.iter_type("msp")
+        assert items is not None
+        assert len(items) == 2
+        assert items[0][6] == [40]
+        assert items[1][6] == [200]
+
+    def test_retain_with_range_predicate(self):
+        annotations = MolecularAnnotations(1000)
+        annotations.add_annotations(
+            "msp",
+            "+",
+            "",
+            starts=[0, 100, 200, 300, 400],
+            lengths=[30, 50, 75, 100, 150],
+        )
+
+        annotations.retain("msp", lambda a: 50 <= a.length < 100)
+
+        items = annotations.iter_type("msp")
+        assert items is not None
+        assert len(items) == 2
+        assert items[0][3] - items[0][2] == 50
+        assert items[1][3] - items[1][2] == 75
+
+    def test_retain_keeps_all(self):
+        annotations = MolecularAnnotations(1000)
+        annotations.add_annotations(
+            "msp", "+", "P", starts=[100, 200], lengths=[50, 60], qualities=[40, 35]
+        )
+
+        annotations.retain("msp", lambda a: True)
+
+        assert annotations.total_annotation_count() == 2
+
+    def test_retain_drops_all(self):
+        annotations = MolecularAnnotations(1000)
+        annotations.add_annotations(
+            "msp", "+", "P", starts=[100, 200], lengths=[50, 60], qualities=[40, 35]
+        )
+
+        annotations.retain("msp", lambda a: False)
+
+        # Type stays in the container but contributes no annotations and
+        # therefore doesn't appear in the emitted MA string.
+        assert annotations.annotation_type_names() == ["msp"]
+        assert annotations.total_annotation_count() == 0
+        assert annotations.to_ma_string() == "1000"
+
+    def test_retain_only_affects_named_type(self):
+        annotations = MolecularAnnotations(1000)
+        annotations.add_annotations(
+            "msp", "+", "P", starts=[100, 200], lengths=[50, 60], qualities=[40, 35]
+        )
+        annotations.add_annotations(
+            "nuc", "+", "", starts=[150, 400], lengths=[147, 147]
+        )
+
+        annotations.retain("msp", lambda a: a.length >= 60)
+
+        msp = annotations.iter_type("msp")
+        nuc = annotations.iter_type("nuc")
+        assert len(msp) == 1
+        assert len(nuc) == 2
+
+    def test_retain_missing_type_is_noop(self):
+        annotations = MolecularAnnotations(1000)
+        annotations.add_annotations("msp", "+", "", starts=[100], lengths=[50])
+
+        # Should not raise; should leave the existing type untouched.
+        annotations.retain("does_not_exist", lambda a: False)
+
+        assert annotations.total_annotation_count() == 1
+
+    def test_retain_exposes_annotation_fields(self):
+        annotations = MolecularAnnotations(1000)
+        annotations.add_annotations(
+            "fire",
+            "-",
+            "Q",
+            starts=[500],
+            lengths=[75],
+            qualities=[200],
+            names=["enhancer1"],
+        )
+
+        seen: list[Annotation] = []
+
+        def collect(a: Annotation) -> bool:
+            seen.append(a)
+            return True
+
+        annotations.retain("fire", collect)
+
+        assert len(seen) == 1
+        a = seen[0]
+        assert a.start == 500
+        assert a.length == 75
+        assert a.end == 575
+        assert a.strand == "-"
+        assert a.qualities == [200]
+        assert a.name == "enhancer1"
+
+    def test_retain_propagates_predicate_exception(self):
+        annotations = MolecularAnnotations(1000)
+        annotations.add_annotations(
+            "msp", "+", "P", starts=[100, 200], lengths=[50, 60], qualities=[40, 35]
+        )
+
+        def bad(a: Annotation) -> bool:
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            annotations.retain("msp", bad)

--- a/python/tests/test_molecular_annotation.py
+++ b/python/tests/test_molecular_annotation.py
@@ -191,16 +191,31 @@ class TestErrorHandling:
                 "test", "+", "", starts=[100, 200], lengths=[50, 60], names=["only_one"]
             )
 
-    def test_conflicting_annotation_type(self):
-        """Test that adding same type with different strand/quality raises error."""
+    def test_conflicting_quality_spec(self):
+        """Test that adding same name with different quality_spec raises error.
+
+        Annotation type identity is keyed on `name` alone, so strand may
+        differ across additions to the same type. quality_spec must agree.
+        """
         annotations = MolecularAnnotations(1000)
         annotations.add_annotations("msp", "+", "P", starts=[100], lengths=[50], qualities=[40])
 
-        with pytest.raises(ValueError, match="already exists"):
-            # Same name but different strand
+        with pytest.raises(ValueError, match="quality_spec"):
+            # Same name but different quality_spec
             annotations.add_annotations(
-                "msp", "-", "P", starts=[200], lengths=[60], qualities=[35]
+                "msp", "+", "Q", starts=[200], lengths=[60], qualities=[35]
             )
+
+    def test_mixed_strand_same_name_merges(self):
+        """Adding the same name with different strand accumulates into one type."""
+        annotations = MolecularAnnotations(1000)
+        annotations.add_annotations("msp", "+", "P", starts=[100], lengths=[50], qualities=[40])
+        # Same name, different strand — should succeed, not error.
+        annotations.add_annotations(
+            "msp", "-", "P", starts=[200], lengths=[60], qualities=[35]
+        )
+        assert annotations.total_annotation_count() == 2
+        assert annotations.annotation_type_names() == ["msp"]
 
     def test_from_tags_invalid_format(self):
         """Test that invalid MA format raises error."""

--- a/rust/examples/fiberseq_to_ma.rs
+++ b/rust/examples/fiberseq_to_ma.rs
@@ -45,10 +45,10 @@ fn fiberseq_to_molecular_annotations(record: &bam::Record) -> Option<MolecularAn
     if let (Some(ns), Some(nl)) = (get_u32_array(record, b"ns"), get_u32_array(record, b"nl")) {
         if ns.len() == nl.len() {
             let nuc_type =
-                annotations.add_annotation_type("nuc", Strand::Forward, QualitySpec::none());
+                annotations.add_annotation_type("nuc", QualitySpec::none());
             for (start, length) in ns.iter().zip(nl.iter()) {
                 // API uses 0-based internally, converts to 1-based when writing MA tag
-                nuc_type.add(*start, *length, vec![], None);
+                nuc_type.add(*start, *length, Strand::Forward, vec![], None);
             }
         }
     }
@@ -70,7 +70,7 @@ fn fiberseq_to_molecular_annotations(record: &bam::Record) -> Option<MolecularAn
                 QualitySpec::none()
             };
 
-            let msp_type = annotations.add_annotation_type("msp", Strand::Forward, quality_spec);
+            let msp_type = annotations.add_annotation_type("msp", quality_spec);
             for (i, (start, length)) in a_starts.iter().zip(al.iter()).enumerate() {
                 let qualities = if has_quality {
                     aq.as_ref()
@@ -81,7 +81,7 @@ fn fiberseq_to_molecular_annotations(record: &bam::Record) -> Option<MolecularAn
                     vec![]
                 };
                 // API uses 0-based internally, converts to 1-based when writing MA tag
-                msp_type.add(*start, *length, qualities, None);
+                msp_type.add(*start, *length, Strand::Forward, qualities, None);
             }
         }
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -121,7 +121,7 @@ mod types;
 pub use liftover::{AlignedBlock, AlignedBlocks};
 pub use types::{
     Annotation, AnnotationInfo, AnnotationType, Encoding, LiftedCoords, ParseError,
-    QualityScaling, QualitySpec, Strand,
+    ProjectedAnnotation, QualityScaling, QualitySpec, Strand,
 };
 
 use std::str::FromStr;
@@ -213,7 +213,8 @@ impl MolecularAnnotations {
             }
             return Ok(&mut self.annotation_types[idx]);
         }
-        self.annotation_types.push(AnnotationType::new(name, quality_spec));
+        self.annotation_types
+            .push(AnnotationType::new(name, quality_spec));
         Ok(self.annotation_types.last_mut().unwrap())
     }
 
@@ -230,7 +231,10 @@ impl MolecularAnnotations {
     /// assert_eq!(annotations.annotation_type_names(), vec!["msp", "nuc"]);
     /// ```
     pub fn annotation_type_names(&self) -> Vec<&str> {
-        self.annotation_types.iter().map(|t| t.name.as_str()).collect()
+        self.annotation_types
+            .iter()
+            .map(|t| t.name.as_str())
+            .collect()
     }
 
     /// Get an annotation type by name
@@ -336,7 +340,10 @@ impl MolecularAnnotations {
 
     /// Returns the total number of annotations across all types
     pub fn total_annotation_count(&self) -> usize {
-        self.annotation_types.iter().map(|t| t.annotations.len()).sum()
+        self.annotation_types
+            .iter()
+            .map(|t| t.annotations.len())
+            .sum()
     }
 
     /// Iterate over all annotations across all types
@@ -452,7 +459,66 @@ impl MolecularAnnotations {
             .iter()
             .flat_map(move |annot_type| self.iter_annotation_type(annot_type))
     }
+    /// Project annotations into a query-coordinate system anchored at 0.
+    ///
+    /// Each annotation's coords (in BAM orientation, matching `iter_full`) are
+    /// shifted by `-anchor`. If `flip` is true, each interval is reversed
+    /// around 0: `[a, b)` → `[-(b-1), -(a-1))`.
+    pub fn project_query(
+        &self,
+        anchor: i64,
+        flip: bool,
+    ) -> impl Iterator<Item = ProjectedAnnotation<'_>> + '_ {
+        self.annotation_types.iter().flat_map(move |t| {
+            t.annotations.iter().map(move |a| {
+                let (qs, qe) = if self.is_reverse_aligned {
+                    self.flip_range(a.start, a.end())
+                } else {
+                    (a.start, a.end())
+                };
+                let (start, end) = project_interval(qs as i64, qe as i64, anchor, flip);
+                ProjectedAnnotation {
+                    type_name: &t.name,
+                    start,
+                    end,
+                    strand: a.strand,
+                    qualities: &a.qualities,
+                    name: a.name.as_deref(),
+                }
+            })
+        })
+    }
 
+    /// Project annotations into a reference-coordinate system anchored at 0.
+    ///
+    /// Requires aligned blocks. Annotations that don't lift to reference
+    /// coords (no blocks, or in a gap) are skipped.
+    pub fn project_reference(
+        &self,
+        anchor: i64,
+        flip: bool,
+    ) -> impl Iterator<Item = ProjectedAnnotation<'_>> + '_ {
+        self.annotation_types.iter().flat_map(move |t| {
+            t.annotations.iter().filter_map(move |a| {
+                let blocks = self.aligned_blocks.as_ref()?;
+                let (qs, qe) = if self.is_reverse_aligned {
+                    self.flip_range(a.start, a.end())
+                } else {
+                    (a.start, a.end())
+                };
+                let (rs, re) = blocks.lift_to_reference(qs, qe);
+                let (start, end) = project_interval(rs? as i64, re? as i64, anchor, flip);
+                Some(ProjectedAnnotation {
+                    type_name: &t.name,
+                    start,
+                    end,
+                    strand: a.strand,
+                    qualities: &a.qualities,
+                    name: a.name.as_deref(),
+                })
+            })
+        })
+    }
     /// Section emission order for MA / AL / AQ / AN serialization.
     ///
     /// For each annotation type (in insertion order), groups its annotations
@@ -462,7 +528,9 @@ impl MolecularAnnotations {
     ///
     /// Yields `(annotation_type, strand, indices)` where `indices` are
     /// positions into `annotation_type.annotations`.
-    fn emission_sections(&self) -> impl Iterator<Item = (&AnnotationType, Strand, Vec<usize>)> + '_ {
+    fn emission_sections(
+        &self,
+    ) -> impl Iterator<Item = (&AnnotationType, Strand, Vec<usize>)> + '_ {
         const STRANDS: [Strand; 3] = [Strand::Forward, Strand::Reverse, Strand::Unknown];
         self.annotation_types.iter().flat_map(|t| {
             STRANDS.into_iter().filter_map(move |s| {
@@ -507,7 +575,11 @@ impl MolecularAnnotations {
                     .collect(),
             };
 
-            parts.push(format!("{}:{}", annot_type.type_signature(strand), positions.join(",")));
+            parts.push(format!(
+                "{}:{}",
+                annot_type.type_signature(strand),
+                positions.join(",")
+            ));
         }
 
         parts.join(";")
@@ -825,10 +897,7 @@ impl MolecularAnnotations {
     /// Vector of [`LiftedCoords`] tuples `(query_start, query_end, ref_start, ref_end)`,
     /// all as 0-based half-open intervals.
     /// Returns `None` if the type doesn't exist or aligned blocks are not set.
-    pub fn get_ref_coords(
-        &self,
-        type_name: &str,
-    ) -> Option<Vec<LiftedCoords>> {
+    pub fn get_ref_coords(&self, type_name: &str) -> Option<Vec<LiftedCoords>> {
         let blocks = self.aligned_blocks.as_ref()?;
         let coords = self.get_coords(type_name)?;
 
@@ -955,7 +1024,10 @@ impl MolecularAnnotations {
             // Split on ':' to get type info and positions
             let type_and_positions: Vec<&str> = part.splitn(2, ':').collect();
             if type_and_positions.len() != 2 {
-                return Err(ParseError::InvalidFormat(format!("Invalid annotation type format: {}", part)));
+                return Err(ParseError::InvalidFormat(format!(
+                    "Invalid annotation type format: {}",
+                    part
+                )));
             }
 
             let type_info = type_and_positions[0];
@@ -974,12 +1046,18 @@ impl MolecularAnnotations {
                 .filter(|s| !s.is_empty())
                 .map(|s| {
                     if let Some((start_str, len_str)) = s.split_once('-') {
-                        let start: u32 = start_str.parse().map_err(|_| ParseError::InvalidCoordinate(format!("Invalid start: {}", start_str)))?;
-                        let len: u32 = len_str.parse().map_err(|_| ParseError::InvalidCoordinate(format!("Invalid length: {}", len_str)))?;
-                        Ok((start - 1, Some(len)))  // Convert 1-based to 0-based
+                        let start: u32 = start_str.parse().map_err(|_| {
+                            ParseError::InvalidCoordinate(format!("Invalid start: {}", start_str))
+                        })?;
+                        let len: u32 = len_str.parse().map_err(|_| {
+                            ParseError::InvalidCoordinate(format!("Invalid length: {}", len_str))
+                        })?;
+                        Ok((start - 1, Some(len))) // Convert 1-based to 0-based
                     } else {
-                        let start: u32 = s.parse().map_err(|_| ParseError::InvalidCoordinate(format!("Invalid position: {}", s)))?;
-                        Ok((start - 1, None))  // Convert 1-based to 0-based
+                        let start: u32 = s.parse().map_err(|_| {
+                            ParseError::InvalidCoordinate(format!("Invalid position: {}", s))
+                        })?;
+                        Ok((start - 1, None)) // Convert 1-based to 0-based
                     }
                 })
                 .collect::<Result<Vec<_>, ParseError>>()?;
@@ -1028,7 +1106,11 @@ impl MolecularAnnotations {
                 let annot_name = if name_idx < names.len() {
                     let n = names[name_idx];
                     name_idx += 1;
-                    if n.is_empty() { None } else { Some(n.to_string()) }
+                    if n.is_empty() {
+                        None
+                    } else {
+                        Some(n.to_string())
+                    }
                 } else {
                     name_idx += 1;
                     None
@@ -1065,13 +1147,14 @@ pub(crate) fn parse_type_info(s: &str) -> Result<(String, Strand, QualitySpec), 
         .find(|(_, c)| *c == '+' || *c == '-' || *c == '.')
         .map(|(i, _)| i);
 
-    let strand_pos = strand_pos.ok_or_else(|| {
-        ParseError::InvalidFormat(format!("No strand indicator found in: {}", s))
-    })?;
+    let strand_pos = strand_pos
+        .ok_or_else(|| ParseError::InvalidFormat(format!("No strand indicator found in: {}", s)))?;
 
     let name = &s[..strand_pos];
     if name.is_empty() {
-        return Err(ParseError::InvalidFormat("Empty annotation type name".to_string()));
+        return Err(ParseError::InvalidFormat(
+            "Empty annotation type name".to_string(),
+        ));
     }
 
     let strand_char = &s[strand_pos..strand_pos + 1];
@@ -1081,6 +1164,18 @@ pub(crate) fn parse_type_info(s: &str) -> Result<(String, Strand, QualitySpec), 
     let quality_spec = QualitySpec::from_str(quality_str)?;
 
     Ok((name.to_string(), strand, quality_spec))
+}
+
+/// Shift `[raw_start, raw_end)` so `anchor` is at 0, optionally flipping
+/// around 0 (reverses orientation): `[a, b)` → `[-(b-1), -(a-1))`.
+#[inline]
+fn project_interval(raw_start: i64, raw_end: i64, anchor: i64, flip: bool) -> (i64, i64) {
+    let (s, e) = (raw_start - anchor, raw_end - anchor);
+    if flip {
+        (-e + 1, -s + 1)
+    } else {
+        (s, e)
+    }
 }
 
 #[cfg(test)]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -127,7 +127,7 @@ pub use types::{
 use std::str::FromStr;
 
 /// Container for all molecular annotations on a read
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct MolecularAnnotations {
     /// Length of the read at the time annotations were made
     pub read_length: u32,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -602,6 +602,17 @@ impl MolecularAnnotations {
         (ma, al, aq, an)
     }
 
+    /// Retain annotations of `type_name` matching `predicate`.
+    /// No-op if the type doesn't exist.
+    pub fn retain<F>(&mut self, type_name: &str, predicate: F)
+    where
+        F: FnMut(&Annotation) -> bool,
+    {
+        if let Some(t) = self.get_type_mut(type_name) {
+            t.retain(predicate);
+        }
+    }
+
     /// Write annotations to a BAM record.
     ///
     /// This sets the MA:Z tag, and optionally AL:B:I, AQ:B:C, and AN:Z tags

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -30,25 +30,26 @@
 //! ```
 //! use molecular_annotation::{MolecularAnnotations, Strand, QualitySpec, Encoding};
 //!
-//! // Build annotations programmatically
+//! // Build annotations programmatically. Annotation type identity is keyed
+//! // on `name` alone — strand is a per-annotation property.
 //! let mut annotations = MolecularAnnotations::new(1000);
 //!
 //! // Add MSP annotations with phred quality scores
 //! annotations
-//!     .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-//!     .add(100, 50, vec![40], None)
-//!     .add(200, 60, vec![35], None);
+//!     .add_annotation_type("msp", "P".parse().unwrap())
+//!     .add(100, 50, Strand::Forward, vec![40], None)
+//!     .add(200, 60, Strand::Forward, vec![35], None);
 //!
 //! // Add nucleosome annotations without quality scores
 //! annotations
-//!     .add_annotation_type("nuc", Strand::Forward, QualitySpec::none())
-//!     .add(150, 147, vec![], None)
-//!     .add(350, 147, vec![], None);
+//!     .add_annotation_type("nuc", QualitySpec::none())
+//!     .add(150, 147, Strand::Forward, vec![], None)
+//!     .add(350, 147, Strand::Forward, vec![], None);
 //!
 //! // Add FIRE annotation with linear quality
 //! annotations
-//!     .add_annotation_type("fire", Strand::Unknown, "Q".parse().unwrap())
-//!     .add(500, 75, vec![200], Some("enhancer1".to_string()));
+//!     .add_annotation_type("fire", "Q".parse().unwrap())
+//!     .add(500, 75, Strand::Unknown, vec![200], Some("enhancer1".to_string()));
 //!
 //! // Add annotation type with multiple quality values per annotation (PQQP = 4 values each)
 //! use molecular_annotation::QualityScaling;
@@ -57,10 +58,12 @@
 //!     QualityScaling::Linear, QualityScaling::Phred,
 //! ]);
 //! annotations
-//!     .add_annotation_type("ctcf", Strand::Forward, pqqp)
-//!     .add(600, 20, vec![40, 200, 180, 35], None);
+//!     .add_annotation_type("ctcf", pqqp)
+//!     .add(600, 20, Strand::Forward, vec![40, 200, 180, 35], None);
 //!
-//! // Serialize with inline encoding (start-length pairs in MA string)
+//! // Serialize with inline encoding (start-length pairs in MA string).
+//! // Sections are emitted per (name, strand): types with annotations on
+//! // multiple strands produce multiple sections sharing the same name.
 //! annotations.set_encoding(Encoding::Inline);
 //! let ma_inline = annotations.to_ma_string();
 //! assert_eq!(ma_inline, "1000;msp+P:101-50,201-60;nuc+:151-147,351-147;fire.Q:501-75;ctcf+PQQP:601-20");
@@ -94,8 +97,8 @@
 //!
 //! let mut annotations = MolecularAnnotations::new(1000);
 //! annotations
-//!     .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-//!     .add(100, 50, vec![40], None);  // query [100, 150) in 0-based half-open
+//!     .add_annotation_type("msp", "P".parse().unwrap())
+//!     .add(100, 50, Strand::Forward, vec![40], None);  // query [100, 150) in 0-based half-open
 //!
 //! // Set aligned blocks for liftover (query positions are forward-oriented)
 //! // Second argument is is_reverse: false for forward-aligned reads
@@ -163,34 +166,66 @@ impl MolecularAnnotations {
         self
     }
 
-    /// Add a new annotation type and return a mutable reference to it.
+    /// Get-or-create the annotation type with the given name.
     ///
-    /// This enables the builder pattern for adding annotations:
+    /// If a type with this `name` already exists with a matching
+    /// `quality_spec`, returns the existing type. If it exists with a
+    /// different `quality_spec`, **panics**. Programmatic callers that need
+    /// fallible behavior should use [`try_add_annotation_type`](Self::try_add_annotation_type).
+    ///
+    /// Annotation type identity is keyed on `name` alone — strand is a
+    /// per-annotation property, supplied via [`AnnotationType::add`].
+    ///
     /// ```ignore
-    /// annotations.add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-    ///     .add(100, 50, vec![40], None)
-    ///     .add(200, 60, vec![35], None);
+    /// annotations.add_annotation_type("msp", "P".parse().unwrap())
+    ///     .add(100, 50, Strand::Forward, vec![40], None)
+    ///     .add(200, 60, Strand::Reverse, vec![35], None);
     /// ```
     pub fn add_annotation_type(
         &mut self,
         name: &str,
-        strand: Strand,
         quality_spec: QualitySpec,
     ) -> &mut AnnotationType {
-        self.annotation_types.push(AnnotationType::new(name.to_string(), strand, quality_spec));
-        // Safety: we just pushed, so last_mut() will always succeed
-        self.annotation_types.last_mut().unwrap()
+        self.try_add_annotation_type(name, quality_spec)
+            .expect("conflicting quality_spec for existing annotation type")
+    }
+
+    /// Fallible variant of [`add_annotation_type`](Self::add_annotation_type).
+    ///
+    /// Returns the existing type if `name` is already present with a matching
+    /// `quality_spec`. Returns [`ParseError::ConflictingAnnotationType`] if
+    /// the existing type has a different `quality_spec`. Otherwise creates
+    /// a new type and returns a mutable reference to it.
+    pub fn try_add_annotation_type(
+        &mut self,
+        name: &str,
+        quality_spec: QualitySpec,
+    ) -> Result<&mut AnnotationType, ParseError> {
+        if let Some(idx) = self.annotation_types.iter().position(|t| t.name == name) {
+            if self.annotation_types[idx].quality_spec != quality_spec {
+                return Err(ParseError::ConflictingAnnotationType {
+                    name: name.to_string(),
+                    reason: format!(
+                        "existing quality_spec {} differs from requested {}",
+                        self.annotation_types[idx].quality_spec, quality_spec
+                    ),
+                });
+            }
+            return Ok(&mut self.annotation_types[idx]);
+        }
+        self.annotation_types.push(AnnotationType::new(name, quality_spec));
+        Ok(self.annotation_types.last_mut().unwrap())
     }
 
     /// Get the names of all annotation types.
     ///
     /// # Example
     /// ```
-    /// use molecular_annotation::{MolecularAnnotations, Strand, QualitySpec};
+    /// use molecular_annotation::{MolecularAnnotations, QualitySpec};
     ///
     /// let mut annotations = MolecularAnnotations::new(1000);
-    /// annotations.add_annotation_type("msp", Strand::Forward, "P".parse().unwrap());
-    /// annotations.add_annotation_type("nuc", Strand::Forward, QualitySpec::none());
+    /// annotations.add_annotation_type("msp", "P".parse().unwrap());
+    /// annotations.add_annotation_type("nuc", QualitySpec::none());
     ///
     /// assert_eq!(annotations.annotation_type_names(), vec!["msp", "nuc"]);
     /// ```
@@ -210,20 +245,24 @@ impl MolecularAnnotations {
 
     /// Add multiple annotations of the same type at once.
     ///
-    /// Accepts 0-based half-open [start, start+length) coordinates.
+    /// Accepts 0-based half-open [start, start+length) coordinates. The
+    /// `strand` parameter is applied to every annotation in this batch.
+    /// Callers needing mixed strands per type call `add_annotations` once
+    /// per strand — both calls land in the same in-memory `AnnotationType`.
     ///
     /// # Arguments
     /// * `name` - Name of the annotation type (e.g., "msp", "nuc", "fire")
-    /// * `strand` - Strand orientation
     /// * `quality_spec` - Quality specification
     /// * `starts` - 0-based start positions
     /// * `lengths` - Lengths of the annotations in base pairs
+    /// * `strand` - Strand applied to every annotation in this batch
     /// * `qualities` - Optional flat quality array. Length must be
     ///   `starts.len() * quality_spec.num_qualities()`.
     /// * `names` - Optional names/labels, must match starts length if provided
     ///
     /// # Errors
-    /// Returns an error if array lengths don't match.
+    /// Returns an error if array lengths don't match, or if `name` already
+    /// exists with a different `quality_spec`.
     ///
     /// # Example
     /// ```
@@ -232,23 +271,24 @@ impl MolecularAnnotations {
     /// let mut annotations = MolecularAnnotations::new(1000);
     /// annotations.add_annotations(
     ///     "msp",
-    ///     Strand::Forward,
     ///     "P".parse().unwrap(),
     ///     &[100, 200, 300],
     ///     &[50, 60, 70],
+    ///     Strand::Forward,
     ///     Some(&[40, 35, 30]),
     ///     None,
     /// ).unwrap();
     ///
     /// assert_eq!(annotations.total_annotation_count(), 3);
     /// ```
+    #[allow(clippy::too_many_arguments)]
     pub fn add_annotations(
         &mut self,
         name: &str,
-        strand: Strand,
         quality_spec: QualitySpec,
         starts: &[u32],
         lengths: &[u32],
+        strand: Strand,
         qualities: Option<&[u8]>,
         names: Option<&[String]>,
     ) -> Result<&mut Self, ParseError> {
@@ -277,24 +317,8 @@ impl MolecularAnnotations {
             }
         }
 
-        // Find or create the annotation type
-        let at = if let Some(existing) = self.get_type_mut(name) {
-            // Verify strand and quality spec match
-            if existing.strand != strand || existing.quality_spec != quality_spec {
-                return Err(ParseError::ConflictingAnnotationType {
-                    name: name.to_string(),
-                    reason: format!(
-                        "existing: {}{}, new: {}{}",
-                        existing.strand, existing.quality_spec, strand, quality_spec
-                    ),
-                });
-            }
-            existing
-        } else {
-            self.add_annotation_type(name, strand, quality_spec)
-        };
+        let at = self.try_add_annotation_type(name, quality_spec)?;
 
-        // Add all annotations
         for i in 0..starts.len() {
             let q = if num_q > 0 {
                 qualities
@@ -303,8 +327,8 @@ impl MolecularAnnotations {
             } else {
                 Vec::new()
             };
-            let name = names.map(|n| n[i].clone());
-            at.add(starts[i], lengths[i], q, name);
+            let n = names.map(|n| n[i].clone());
+            at.add(starts[i], lengths[i], strand, q, n);
         }
 
         Ok(self)
@@ -338,8 +362,8 @@ impl MolecularAnnotations {
     ///
     /// let mut annotations = MolecularAnnotations::new(1000);
     /// annotations
-    ///     .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-    ///     .add(100, 50, vec![40], None);
+    ///     .add_annotation_type("msp", "P".parse().unwrap())
+    ///     .add(100, 50, Strand::Forward, vec![40], None);
     ///
     /// // Collect into a Vec to avoid lifetime issues
     /// let msp_annotations: Vec<_> = annotations.iter_type("msp")
@@ -379,7 +403,7 @@ impl MolecularAnnotations {
 
             AnnotationInfo {
                 type_name: &annot_type.name,
-                strand: annot_type.strand,
+                strand: a.strand,
                 quality_spec: &annot_type.quality_spec,
                 query_start,
                 query_end,
@@ -411,8 +435,8 @@ impl MolecularAnnotations {
     ///
     /// let mut annotations = MolecularAnnotations::new(1000);
     /// annotations
-    ///     .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-    ///     .add(100, 50, vec![40], None);
+    ///     .add_annotation_type("msp", "P".parse().unwrap())
+    ///     .add(100, 50, Strand::Forward, vec![40], None);
     ///
     /// for info in annotations.iter_full() {
     ///     println!("{}: [{}, {}) qualities={:?}",
@@ -429,48 +453,86 @@ impl MolecularAnnotations {
             .flat_map(move |annot_type| self.iter_annotation_type(annot_type))
     }
 
+    /// Section emission order for MA / AL / AQ / AN serialization.
+    ///
+    /// For each annotation type (in insertion order), groups its annotations
+    /// by [`Strand`] in enum order (`Forward`, `Reverse`, `Unknown`). Each
+    /// non-empty group becomes one section. Within a group, annotation order
+    /// follows insertion order.
+    ///
+    /// Yields `(annotation_type, strand, indices)` where `indices` are
+    /// positions into `annotation_type.annotations`.
+    fn emission_sections(&self) -> impl Iterator<Item = (&AnnotationType, Strand, Vec<usize>)> + '_ {
+        const STRANDS: [Strand; 3] = [Strand::Forward, Strand::Reverse, Strand::Unknown];
+        self.annotation_types.iter().flat_map(|t| {
+            STRANDS.into_iter().filter_map(move |s| {
+                let indices: Vec<usize> = t
+                    .annotations
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, a)| a.strand == s)
+                    .map(|(i, _)| i)
+                    .collect();
+                if indices.is_empty() {
+                    None
+                } else {
+                    Some((t, s, indices))
+                }
+            })
+        })
+    }
+
     /// Generate the MA:Z tag string.
     ///
     /// Converts internal 0-based half-open to 1-based closed per MA tag spec
-    /// (internal `start=99` → MA tag `100`).
+    /// (internal `start=99` → MA tag `100`). Annotations within each type
+    /// are grouped by strand into sections; types with annotations on
+    /// multiple strands emit multiple sections sharing the same `name`.
+    /// Empty types emit no section.
     pub fn to_ma_string(&self) -> String {
         let mut parts = vec![self.read_length.to_string()];
 
-        for annot_type in &self.annotation_types {
+        for (annot_type, strand, indices) in self.emission_sections() {
             let positions: Vec<String> = match self.encoding {
-                Encoding::Inline => annot_type
-                    .annotations
+                Encoding::Inline => indices
                     .iter()
-                    .map(|a| format!("{}-{}", a.start + 1, a.length))  // Convert 0-based to 1-based
+                    .map(|&i| {
+                        let a = &annot_type.annotations[i];
+                        format!("{}-{}", a.start + 1, a.length)
+                    })
                     .collect(),
-                Encoding::Separate => annot_type
-                    .annotations
+                Encoding::Separate => indices
                     .iter()
-                    .map(|a| (a.start + 1).to_string())  // Convert 0-based to 1-based
+                    .map(|&i| (annot_type.annotations[i].start + 1).to_string())
                     .collect(),
             };
 
-            parts.push(format!("{}:{}", annot_type.type_signature(), positions.join(",")));
+            parts.push(format!("{}:{}", annot_type.type_signature(strand), positions.join(",")));
         }
 
         parts.join(";")
     }
 
-    /// Generate the AL:B:I array (lengths)
+    /// Generate the AL:B:I array (lengths). Order matches MA section order.
     pub fn to_al_array(&self) -> Vec<u32> {
-        self.annotation_types
-            .iter()
-            .flat_map(|t| t.annotations.iter().map(|a| a.length))
+        self.emission_sections()
+            .flat_map(|(t, _strand, indices)| {
+                indices.into_iter().map(move |i| t.annotations[i].length)
+            })
             .collect()
     }
 
-    /// Generate the AQ:B:C array (None if no annotations have quality)
+    /// Generate the AQ:B:C array (None if no annotations have quality).
+    /// Order matches MA section order.
     pub fn to_aq_array(&self) -> Option<Vec<u8>> {
         let qualities: Vec<u8> = self
-            .annotation_types
-            .iter()
-            .filter(|t| t.quality_spec.has_quality())
-            .flat_map(|t| t.annotations.iter().flat_map(|a| a.qualities.iter().copied()))
+            .emission_sections()
+            .filter(|(t, _, _)| t.quality_spec.has_quality())
+            .flat_map(|(t, _strand, indices)| {
+                indices
+                    .into_iter()
+                    .flat_map(move |i| t.annotations[i].qualities.iter().copied())
+            })
             .collect();
 
         if qualities.is_empty() {
@@ -480,7 +542,8 @@ impl MolecularAnnotations {
         }
     }
 
-    /// Generate the AN:Z tag string (None if no annotations have names)
+    /// Generate the AN:Z tag string (None if no annotations have names).
+    /// Order matches MA section order.
     pub fn to_an_string(&self) -> Option<String> {
         let has_any_names = self
             .annotation_types
@@ -492,12 +555,11 @@ impl MolecularAnnotations {
         }
 
         let names: Vec<String> = self
-            .annotation_types
-            .iter()
-            .flat_map(|t| {
-                t.annotations.iter().map(|a| {
-                    a.name.as_deref().unwrap_or("").to_string()
-                })
+            .emission_sections()
+            .flat_map(|(t, _strand, indices)| {
+                indices
+                    .into_iter()
+                    .map(move |i| t.annotations[i].name.as_deref().unwrap_or("").to_string())
             })
             .collect();
 
@@ -519,8 +581,8 @@ impl MolecularAnnotations {
     ///
     /// let mut annotations = MolecularAnnotations::new(1000);
     /// annotations
-    ///     .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-    ///     .add(99, 50, vec![40], None);  // 0-based
+    ///     .add_annotation_type("msp", "P".parse().unwrap())
+    ///     .add(99, 50, Strand::Forward, vec![40], None);  // 0-based
     ///
     /// let (ma, al, aq, an) = annotations.to_tags();
     /// assert_eq!(ma, "1000;msp+P:100-50");  // 1-based in tag
@@ -863,11 +925,15 @@ impl MolecularAnnotations {
         let names: Vec<&str> = an.map(|s| s.split(',').collect()).unwrap_or_default();
 
         // Track position in AL and AQ arrays
-        let mut al_idx = 0;
-        let mut aq_idx = 0;
-        let mut name_idx = 0;
+        let mut al_idx = 0usize;
+        let mut aq_idx = 0usize;
+        let mut name_idx = 0usize;
 
-        let mut annotation_types = Vec::new();
+        // Build incrementally so try_add_annotation_type is the dedup
+        // choke point: same `name` across multiple sections accumulates
+        // into one in-memory AnnotationType, with per-annotation strand
+        // carried over from each section header.
+        let mut out = MolecularAnnotations::new(read_length);
 
         // Parse each annotation type section
         for part in &parts[1..] {
@@ -907,8 +973,8 @@ impl MolecularAnnotations {
                 })
                 .collect::<Result<Vec<_>, ParseError>>()?;
 
-            // Create annotations
-            let mut annot_type = AnnotationType::new(name, strand, quality_spec);
+            // Get-or-merge into the existing AnnotationType for `name`.
+            let at = out.try_add_annotation_type(&name, quality_spec.clone())?;
 
             for (pos, inline_length) in position_length_pairs {
                 // Get length: from inline format or from AL array
@@ -957,10 +1023,8 @@ impl MolecularAnnotations {
                     None
                 };
 
-                annot_type.annotations.push(Annotation::new(pos, length, qualities, annot_name));
+                at.add(pos, length, strand, qualities, annot_name);
             }
-
-            annotation_types.push(annot_type);
         }
 
         // Validate that we consumed all AL values (only if using separate format)
@@ -972,19 +1036,13 @@ impl MolecularAnnotations {
         }
 
         // Detect encoding from input format
-        let detected_encoding = if al_idx == 0 && !annotation_types.is_empty() {
+        out.encoding = if al_idx == 0 && !out.annotation_types.is_empty() {
             Encoding::Inline
         } else {
             Encoding::Separate
         };
 
-        Ok(Self {
-            read_length,
-            annotation_types,
-            encoding: detected_encoding,
-            aligned_blocks: None,
-            is_reverse_aligned: false,
-        })
+        Ok(out)
     }
 }
 

--- a/rust/src/liftover.rs
+++ b/rust/src/liftover.rs
@@ -103,7 +103,7 @@ impl AlignedBlock {
 /// between query (read) and reference coordinate systems.
 ///
 /// Query positions are assumed to be forward-oriented (as stored in the MA tag).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct AlignedBlocks {
     blocks: Vec<AlignedBlock>,
     /// Length of the query sequence

--- a/rust/src/tests.rs
+++ b/rust/src/tests.rs
@@ -52,7 +52,7 @@ fn test_quality_spec_parsing() {
 #[test]
 fn test_annotation_end() {
     // 0-based half-open: start=100, length=50 -> end=150
-    let a = Annotation::new(100, 50, vec![], None);
+    let a = Annotation::new(100, 50, Strand::Forward, vec![], None);
     assert_eq!(a.end(), 150);
 }
 
@@ -88,9 +88,9 @@ fn test_parse_type_info() {
 fn test_builder_pattern() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(100, 50, vec![40], None)  // [100, 150)
-        .add(200, 60, vec![35], None); // [200, 260)
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None)  // [100, 150)
+        .add(200, 60, Strand::Forward, vec![35], None); // [200, 260)
 
     assert_eq!(annotations.read_length, 1000);
     assert_eq!(annotations.annotation_types.len(), 1);
@@ -103,9 +103,9 @@ fn test_to_ma_string_inline() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations.set_encoding(Encoding::Inline);
     annotations
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(99, 50, vec![40], None)   // 0-based 99 -> 1-based 100 in tag
-        .add(199, 60, vec![35], None); // 0-based 199 -> 1-based 200 in tag
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(99, 50, Strand::Forward, vec![40], None)   // 0-based 99 -> 1-based 100 in tag
+        .add(199, 60, Strand::Forward, vec![35], None); // 0-based 199 -> 1-based 200 in tag
 
     assert_eq!(annotations.to_ma_string(), "1000;msp+P:100-50,200-60");
 }
@@ -116,9 +116,9 @@ fn test_to_ma_string_separate() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations.set_encoding(Encoding::Separate);
     annotations
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(99, 50, vec![40], None)   // 0-based 99 -> 1-based 100 in tag
-        .add(199, 60, vec![35], None); // 0-based 199 -> 1-based 200 in tag
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(99, 50, Strand::Forward, vec![40], None)   // 0-based 99 -> 1-based 100 in tag
+        .add(199, 60, Strand::Forward, vec![35], None); // 0-based 199 -> 1-based 200 in tag
 
     assert_eq!(annotations.to_ma_string(), "1000;msp+P:100,200");
 }
@@ -127,9 +127,9 @@ fn test_to_ma_string_separate() {
 fn test_to_al_array() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(100, 50, vec![40], None)
-        .add(200, 60, vec![35], None);
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None)
+        .add(200, 60, Strand::Forward, vec![35], None);
 
     assert_eq!(annotations.to_al_array(), vec![50, 60]);
 }
@@ -138,9 +138,9 @@ fn test_to_al_array() {
 fn test_to_aq_array() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(100, 50, vec![40], None)
-        .add(200, 60, vec![35], None);
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None)
+        .add(200, 60, Strand::Forward, vec![35], None);
 
     assert_eq!(annotations.to_aq_array(), Some(vec![40, 35]));
 }
@@ -149,8 +149,8 @@ fn test_to_aq_array() {
 fn test_to_aq_array_no_quality() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, QualitySpec::none())
-        .add(100, 50, vec![], None);
+        .add_annotation_type("msp", QualitySpec::none())
+        .add(100, 50, Strand::Forward, vec![], None);
 
     assert_eq!(annotations.to_aq_array(), None);
 }
@@ -160,9 +160,9 @@ fn test_to_aq_array_multi_quality() {
     let mut annotations = MolecularAnnotations::new(1000);
     let pq = QualitySpec::from_str("PQ").unwrap();
     annotations
-        .add_annotation_type("msp", Strand::Forward, pq)
-        .add(100, 50, vec![40, 255], None)
-        .add(200, 60, vec![30, 200], None);
+        .add_annotation_type("msp", pq)
+        .add(100, 50, Strand::Forward, vec![40, 255], None)
+        .add(200, 60, Strand::Forward, vec![30, 200], None);
 
     // Should be: [msp1_P, msp1_Q, msp2_P, msp2_Q]
     assert_eq!(annotations.to_aq_array(), Some(vec![40, 255, 30, 200]));
@@ -173,14 +173,14 @@ fn test_to_aq_array_mixed_multi_quality() {
     let mut annotations = MolecularAnnotations::new(1000);
     let pq = QualitySpec::from_str("PQ").unwrap();
     annotations
-        .add_annotation_type("msp", Strand::Forward, pq)
-        .add(100, 50, vec![40, 255], None);
+        .add_annotation_type("msp", pq)
+        .add(100, 50, Strand::Forward, vec![40, 255], None);
     annotations
-        .add_annotation_type("nuc", Strand::Forward, QualitySpec::none())
-        .add(200, 147, vec![], None);
+        .add_annotation_type("nuc", QualitySpec::none())
+        .add(200, 147, Strand::Forward, vec![], None);
     annotations
-        .add_annotation_type("fire", Strand::Unknown, "P".parse().unwrap())
-        .add(500, 75, vec![200], None);
+        .add_annotation_type("fire", "P".parse().unwrap())
+        .add(500, 75, Strand::Unknown, vec![200], None);
 
     // msp contributes 2 values, nuc contributes 0, fire contributes 1
     assert_eq!(annotations.to_aq_array(), Some(vec![40, 255, 200]));
@@ -190,9 +190,9 @@ fn test_to_aq_array_mixed_multi_quality() {
 fn test_to_an_string() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(100, 50, vec![40], Some("first".to_string()))
-        .add(200, 60, vec![35], None);
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], Some("first".to_string()))
+        .add(200, 60, Strand::Forward, vec![35], None);
 
     assert_eq!(annotations.to_an_string(), Some("first,".to_string()));
 }
@@ -211,7 +211,7 @@ fn test_from_tags_simple() {
 
     let msp = &annotations.annotation_types[0];
     assert_eq!(msp.name, "msp");
-    assert_eq!(msp.strand, Strand::Forward);
+    assert_eq!(msp.annotations[0].strand, Strand::Forward);
     assert_eq!(msp.quality_spec, "P".parse().unwrap());
     assert_eq!(msp.annotations.len(), 2);
     assert_eq!(msp.annotations[0].start, 99);   // 1-based 100 -> 0-based 99
@@ -306,13 +306,13 @@ fn test_roundtrip_separate() {
     let mut original = MolecularAnnotations::new(1000);
     original.set_encoding(Encoding::Separate);
     original
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(99, 50, vec![40], Some("first".to_string()))
-        .add(199, 60, vec![35], None);
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(99, 50, Strand::Forward, vec![40], Some("first".to_string()))
+        .add(199, 60, Strand::Forward, vec![35], None);
     original
-        .add_annotation_type("nuc", Strand::Forward, QualitySpec::none())
-        .add(149, 103, vec![], None)
-        .add(299, 100, vec![], Some("nuc2".to_string()));
+        .add_annotation_type("nuc", QualitySpec::none())
+        .add(149, 103, Strand::Forward, vec![], None)
+        .add(299, 100, Strand::Forward, vec![], Some("nuc2".to_string()));
 
     let ma = original.to_ma_string();
     let al = original.to_al_array();
@@ -322,8 +322,8 @@ fn test_roundtrip_separate() {
     let parsed = MolecularAnnotations::from_tags(
         &ma,
         &al,
-        aq.as_ref().map(|v| v.as_slice()),
-        an.as_ref().map(|s| s.as_str()),
+        aq.as_deref(),
+        an.as_deref(),
     )
     .unwrap();
 
@@ -332,12 +332,12 @@ fn test_roundtrip_separate() {
 
     for (orig_type, parsed_type) in original.annotation_types.iter().zip(parsed.annotation_types.iter()) {
         assert_eq!(orig_type.name, parsed_type.name);
-        assert_eq!(orig_type.strand, parsed_type.strand);
         assert_eq!(orig_type.quality_spec, parsed_type.quality_spec);
         assert_eq!(orig_type.annotations.len(), parsed_type.annotations.len());
         for (orig_annot, parsed_annot) in orig_type.annotations.iter().zip(parsed_type.annotations.iter()) {
             assert_eq!(orig_annot.start, parsed_annot.start);
             assert_eq!(orig_annot.length, parsed_annot.length);
+            assert_eq!(orig_annot.strand, parsed_annot.strand);
         }
     }
 }
@@ -347,9 +347,9 @@ fn test_roundtrip_inline() {
     let mut original = MolecularAnnotations::new(1000);
     original.set_encoding(Encoding::Inline);
     original
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(99, 50, vec![40], None)
-        .add(199, 60, vec![35], None);
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(99, 50, Strand::Forward, vec![40], None)
+        .add(199, 60, Strand::Forward, vec![35], None);
 
     let ma = original.to_ma_string();
     let aq = original.to_aq_array();
@@ -357,7 +357,7 @@ fn test_roundtrip_inline() {
     let parsed = MolecularAnnotations::from_tags(
         &ma,
         &[],
-        aq.as_ref().map(|v| v.as_slice()),
+        aq.as_deref(),
         None,
     )
     .unwrap();
@@ -377,9 +377,9 @@ fn test_roundtrip_multi_quality() {
     original.set_encoding(Encoding::Inline);
     let pq = QualitySpec::from_str("PQ").unwrap();
     original
-        .add_annotation_type("msp", Strand::Forward, pq)
-        .add(99, 50, vec![40, 255], None)
-        .add(199, 60, vec![30, 200], None);
+        .add_annotation_type("msp", pq)
+        .add(99, 50, Strand::Forward, vec![40, 255], None)
+        .add(199, 60, Strand::Forward, vec![30, 200], None);
 
     let ma = original.to_ma_string();
     let aq = original.to_aq_array();
@@ -390,7 +390,7 @@ fn test_roundtrip_multi_quality() {
     let parsed = MolecularAnnotations::from_tags(
         &ma,
         &[],
-        aq.as_ref().map(|v| v.as_slice()),
+        aq.as_deref(),
         None,
     )
     .unwrap();
@@ -404,12 +404,12 @@ fn test_roundtrip_multi_quality() {
 fn test_iter_all_annotations() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(100, 50, vec![40], None)
-        .add(200, 60, vec![35], None);
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None)
+        .add(200, 60, Strand::Forward, vec![35], None);
     annotations
-        .add_annotation_type("nuc", Strand::Forward, QualitySpec::none())
-        .add(150, 103, vec![], None);
+        .add_annotation_type("nuc", QualitySpec::none())
+        .add(150, 103, Strand::Forward, vec![], None);
 
     let all: Vec<_> = annotations.iter_all_annotations().collect();
     assert_eq!(all.len(), 3);
@@ -422,12 +422,12 @@ fn test_iter_all_annotations() {
 fn test_total_annotation_count() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(100, 50, vec![40], None)
-        .add(200, 60, vec![35], None);
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None)
+        .add(200, 60, Strand::Forward, vec![35], None);
     annotations
-        .add_annotation_type("nuc", Strand::Forward, QualitySpec::none())
-        .add(150, 103, vec![], None);
+        .add_annotation_type("nuc", QualitySpec::none())
+        .add(150, 103, Strand::Forward, vec![], None);
 
     assert_eq!(annotations.total_annotation_count(), 3);
 }
@@ -452,8 +452,8 @@ fn test_set_aligned_blocks() {
 fn test_annotation_ref_coords() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(100, 50, vec![40], None);  // query [100, 150)
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None);  // query [100, 150)
 
     // Set aligned blocks: query [0, 500) -> ref [1000, 1500)
     // So query [100, 150) -> ref [1100, 1150)
@@ -475,9 +475,9 @@ fn test_annotation_ref_coords() {
 fn test_get_ref_coords() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(100, 50, vec![40], None)   // query [100, 150)
-        .add(200, 60, vec![35], None);  // query [200, 260)
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None)   // query [100, 150)
+        .add(200, 60, Strand::Forward, vec![35], None);  // query [200, 260)
 
     annotations.set_aligned_blocks(
         vec![([0, 500], [1000, 1500])],
@@ -537,8 +537,8 @@ fn test_clear_aligned_blocks() {
 fn test_annotation_in_gap_exact_mode() {
     let mut annotations = MolecularAnnotations::new(500);
     annotations
-        .add_annotation_type("test", Strand::Forward, QualitySpec::none())
-        .add(120, 30, vec![], None);  // query [120, 150), which is in a gap
+        .add_annotation_type("test", QualitySpec::none())
+        .add(120, 30, Strand::Forward, vec![], None);  // query [120, 150), which is in a gap
 
     // Aligned blocks with a gap: [0,100) and [200,300)
     annotations.set_aligned_blocks(vec![
@@ -586,8 +586,8 @@ fn test_reverse_aligned_via_set_aligned_blocks() {
 fn test_get_ref_coords_forward_aligned() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, QualitySpec::none())
-        .add(100, 50, vec![], None);  // [100, 150)
+        .add_annotation_type("msp", QualitySpec::none())
+        .add(100, 50, Strand::Forward, vec![], None);  // [100, 150)
 
     annotations.set_aligned_blocks(
         vec![([0, 500], [1000, 1500])],
@@ -606,8 +606,8 @@ fn test_get_ref_coords_forward_aligned() {
 fn test_get_ref_coords_reverse_aligned() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, QualitySpec::none())
-        .add(600, 50, vec![], None);  // [600, 650) in molecular orientation
+        .add_annotation_type("msp", QualitySpec::none())
+        .add(600, 50, Strand::Forward, vec![], None);  // [600, 650) in molecular orientation
 
     annotations.set_aligned_blocks(
         vec![([0, 500], [1000, 1500])],
@@ -626,8 +626,8 @@ fn test_get_ref_coords_reverse_aligned() {
 fn test_get_ref_coords_reverse_outside_aligned_region() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, QualitySpec::none())
-        .add(100, 50, vec![], None);  // [100, 150) in molecular orientation
+        .add_annotation_type("msp", QualitySpec::none())
+        .add(100, 50, Strand::Forward, vec![], None);  // [100, 150) in molecular orientation
 
     annotations.set_aligned_blocks(
         vec![([0, 500], [1000, 1500])],
@@ -668,10 +668,10 @@ fn test_add_annotations_batch() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations.add_annotations(
         "msp",
-        Strand::Forward,
         "P".parse().unwrap(),
         &[100, 200, 300],
         &[50, 60, 70],
+        Strand::Forward,
         Some(&[40, 35, 30]),
         None,
     ).unwrap();
@@ -691,10 +691,10 @@ fn test_add_annotations_batch_multi_quality() {
     let pq = QualitySpec::from_str("PQ").unwrap();
     annotations.add_annotations(
         "msp",
-        Strand::Forward,
         pq,
         &[100, 200],
         &[50, 60],
+        Strand::Forward,
         // Flat array: 2 annotations * 2 qualities each = 4 values
         Some(&[40, 255, 30, 200]),
         None,
@@ -711,10 +711,10 @@ fn test_add_annotations_batch_error_mismatched_lengths() {
     let mut annotations = MolecularAnnotations::new(1000);
     let result = annotations.add_annotations(
         "msp",
-        Strand::Forward,
         "P".parse().unwrap(),
         &[100, 200],
         &[50],  // Wrong length
+        Strand::Forward,
         None,
         None,
     );
@@ -727,10 +727,10 @@ fn test_add_annotations_batch_error_mismatched_qualities() {
     let pq = QualitySpec::from_str("PQ").unwrap();
     let result = annotations.add_annotations(
         "msp",
-        Strand::Forward,
         pq,
         &[100, 200],
         &[50, 60],
+        Strand::Forward,
         Some(&[40, 255, 30]),  // Should be 4 values (2 annotations * 2 quals)
         None,
     );
@@ -741,9 +741,9 @@ fn test_add_annotations_batch_error_mismatched_qualities() {
 fn test_get_forward_coords() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, QualitySpec::none())
-        .add(100, 50, vec![], None)
-        .add(200, 60, vec![], None);
+        .add_annotation_type("msp", QualitySpec::none())
+        .add(100, 50, Strand::Forward, vec![], None)
+        .add(200, 60, Strand::Forward, vec![], None);
 
     // Forward coords should always return molecular orientation
     let coords = annotations.get_forward_coords("msp").unwrap();
@@ -763,9 +763,9 @@ fn test_get_forward_coords() {
 fn test_iter_full_basic() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(100, 50, vec![40], Some("first".to_string()))
-        .add(200, 60, vec![35], None);
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], Some("first".to_string()))
+        .add(200, 60, Strand::Forward, vec![35], None);
 
     let all: Vec<_> = annotations.iter_full().collect();
     assert_eq!(all.len(), 2);
@@ -795,9 +795,9 @@ fn test_iter_full_multi_quality() {
     let mut annotations = MolecularAnnotations::new(1000);
     let pq = QualitySpec::from_str("PQ").unwrap();
     annotations
-        .add_annotation_type("msp", Strand::Forward, pq)
-        .add(100, 50, vec![40, 255], None)
-        .add(200, 60, vec![30, 200], None);
+        .add_annotation_type("msp", pq)
+        .add(100, 50, Strand::Forward, vec![40, 255], None)
+        .add(200, 60, Strand::Forward, vec![30, 200], None);
 
     let all: Vec<_> = annotations.iter_full().collect();
     assert_eq!(all.len(), 2);
@@ -810,8 +810,8 @@ fn test_iter_full_multi_quality() {
 fn test_iter_full_with_liftover() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, QualitySpec::none())
-        .add(100, 50, vec![], None);
+        .add_annotation_type("msp", QualitySpec::none())
+        .add(100, 50, Strand::Forward, vec![], None);
 
     annotations.set_aligned_blocks(
         vec![([0, 500], [1000, 1500])],
@@ -830,8 +830,8 @@ fn test_iter_full_with_liftover() {
 fn test_iter_full_reverse_aligned() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, QualitySpec::none())
-        .add(600, 50, vec![], None);  // [600, 650) in molecular orientation
+        .add_annotation_type("msp", QualitySpec::none())
+        .add(600, 50, Strand::Forward, vec![], None);  // [600, 650) in molecular orientation
 
     annotations.set_aligned_blocks(
         vec![([0, 500], [1000, 1500])],
@@ -859,8 +859,8 @@ fn test_iter_full_reverse_aligned() {
 fn test_get_bam_coords_alias() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(100, 50, vec![40], None);
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None);
 
     let coords1 = annotations.get_coords("msp").unwrap();
     let coords2 = annotations.get_bam_coords("msp").unwrap();
@@ -871,8 +871,8 @@ fn test_get_bam_coords_alias() {
 fn test_get_molecular_coords_alias() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(100, 50, vec![40], None);
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None);
 
     let coords1 = annotations.get_forward_coords("msp").unwrap();
     let coords2 = annotations.get_molecular_coords("msp").unwrap();
@@ -883,8 +883,8 @@ fn test_get_molecular_coords_alias() {
 fn test_get_molecular_coords_not_affected_by_reverse() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(600, 50, vec![40], None);  // [600, 650)
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(600, 50, Strand::Forward, vec![40], None);  // [600, 650)
 
     annotations.set_aligned_blocks(
         vec![([0, 1000], [1000, 2000])],
@@ -900,40 +900,61 @@ fn test_get_molecular_coords_not_affected_by_reverse() {
 
 #[test]
 fn test_checked_end() {
-    let a = Annotation::new(100, 50, vec![], None);
+    let a = Annotation::new(100, 50, Strand::Forward, vec![], None);
     assert_eq!(a.checked_end(), Some(150));
 
-    let b = Annotation::new(1000000, 1000000, vec![], None);
+    let b = Annotation::new(1000000, 1000000, Strand::Forward, vec![], None);
     assert_eq!(b.checked_end(), Some(2000000));
 }
 
 #[test]
-fn test_conflicting_annotation_type_error() {
+fn test_add_annotations_conflicting_quality_spec_error() {
+    // Annotation type identity is keyed on name; quality_spec must agree
+    // for the same name. Strand may differ across additions to the same
+    // type — see test_add_annotations_mixed_strand_merges_into_one_type.
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(100, 50, vec![40], None);
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None);
 
-    // Try to add same type with different strand - should error
     let result = annotations.add_annotations(
         "msp",
-        Strand::Reverse,  // Different strand!
-        "P".parse().unwrap(),
+        "Q".parse().unwrap(),  // Different quality_spec for same name
         &[200],
         &[60],
+        Strand::Reverse,
         Some(&[35]),
         None,
     );
 
     assert!(result.is_err());
     match result.unwrap_err() {
-        ParseError::ConflictingAnnotationType { name, reason } => {
+        ParseError::ConflictingAnnotationType { name, .. } => {
             assert_eq!(name, "msp");
-            assert!(reason.contains("+P"));  // existing
-            assert!(reason.contains("-P"));  // attempted
         }
         other => panic!("Expected ConflictingAnnotationType, got {:?}", other),
     }
+}
+
+#[test]
+fn test_add_annotations_mixed_strand_merges_into_one_type() {
+    // Two add_annotations calls with different strands but matching
+    // (name, quality_spec) accumulate into a single in-memory type.
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations.add_annotations(
+        "msp", "P".parse().unwrap(),
+        &[100], &[50], Strand::Forward, Some(&[40]), None,
+    ).unwrap();
+    annotations.add_annotations(
+        "msp", "P".parse().unwrap(),
+        &[200], &[60], Strand::Reverse, Some(&[35]), None,
+    ).unwrap();
+
+    assert_eq!(annotations.annotation_types.len(), 1);
+    let msp = annotations.get_type("msp").unwrap();
+    assert_eq!(msp.annotations.len(), 2);
+    assert_eq!(msp.annotations[0].strand, Strand::Forward);
+    assert_eq!(msp.annotations[1].strand, Strand::Reverse);
 }
 
 // =========================================================================
@@ -951,12 +972,18 @@ fn test_empty_annotations_serialization() {
 }
 
 #[test]
-fn test_annotation_type_with_no_annotations() {
+fn test_annotation_type_with_no_annotations_drops_from_emission() {
+    // Empty types have no annotations and therefore no strand to anchor a
+    // section header on — they're dropped from emission entirely. This
+    // aligns with the existing MA-tag regex which requires at least one
+    // \d+-\d+ per section.
     let mut annotations = MolecularAnnotations::new(1000);
-    annotations.add_annotation_type("empty", Strand::Forward, QualitySpec::none());
+    annotations.add_annotation_type("empty", QualitySpec::none());
 
-    assert_eq!(annotations.to_ma_string(), "1000;empty+:");
+    assert_eq!(annotations.to_ma_string(), "1000");
     assert_eq!(annotations.total_annotation_count(), 0);
+    // The in-memory type still exists, just with zero annotations.
+    assert_eq!(annotations.annotation_types.len(), 1);
 }
 
 #[test]
@@ -966,10 +993,10 @@ fn test_quality_boundary_values() {
     // Test with quality = 0 (minimum)
     annotations.add_annotations(
         "min_qual",
-        Strand::Forward,
         "P".parse().unwrap(),
         &[100],
         &[50],
+        Strand::Forward,
         Some(&[0]),  // Minimum quality
         None,
     ).unwrap();
@@ -977,10 +1004,10 @@ fn test_quality_boundary_values() {
     // Test with quality = 255 (maximum for u8)
     annotations.add_annotations(
         "max_qual",
-        Strand::Forward,
         "Q".parse().unwrap(),
         &[200],
         &[60],
+        Strand::Forward,
         Some(&[255]),  // Maximum quality
         None,
     ).unwrap();
@@ -993,8 +1020,8 @@ fn test_quality_boundary_values() {
 fn test_reverse_aligned_with_multiple_blocks() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("msp", Strand::Forward, "P".parse().unwrap())
-        .add(100, 50, vec![40], None);  // Original coords [100, 150)
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None);  // Original coords [100, 150)
 
     annotations.set_aligned_blocks(vec![
         ([0, 400], [1000, 1400]),
@@ -1013,8 +1040,8 @@ fn test_reverse_aligned_with_multiple_blocks() {
 fn test_annotation_spanning_aligned_block_gap() {
     let mut annotations = MolecularAnnotations::new(500);
     annotations
-        .add_annotation_type("spanning", Strand::Forward, QualitySpec::none())
-        .add(50, 200, vec![], None);  // [50, 250) spans across the gap
+        .add_annotation_type("spanning", QualitySpec::none())
+        .add(50, 200, Strand::Forward, vec![], None);  // [50, 250) spans across the gap
 
     annotations.set_aligned_blocks(vec![
         ([0, 100], [1000, 1100]),
@@ -1030,8 +1057,8 @@ fn test_annotation_spanning_aligned_block_gap() {
 fn test_zero_length_annotation() {
     let mut annotations = MolecularAnnotations::new(1000);
     annotations
-        .add_annotation_type("point", Strand::Forward, QualitySpec::none())
-        .add(100, 0, vec![], None);  // [100, 100) - zero length
+        .add_annotation_type("point", QualitySpec::none())
+        .add(100, 0, Strand::Forward, vec![], None);  // [100, 100) - zero length
 
     assert_eq!(annotations.total_annotation_count(), 1);
 
@@ -1040,4 +1067,114 @@ fn test_zero_length_annotation() {
     assert_eq!(annot.end(), 100);
 
     assert_eq!(annotations.to_ma_string(), "1000;point+:101-0");
+}
+
+#[test]
+fn test_add_annotation_type_same_name_returns_existing() {
+    // Two .add_annotation_type("msp", ...) calls with matching quality_spec
+    // must return references into the same underlying AnnotationType.
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None);
+    annotations
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(200, 60, Strand::Reverse, vec![35], None);
+
+    assert_eq!(annotations.annotation_types.len(), 1);
+    let msp = annotations.get_type("msp").unwrap();
+    assert_eq!(msp.annotations.len(), 2);
+    assert_eq!(msp.annotations[0].strand, Strand::Forward);
+    assert_eq!(msp.annotations[1].strand, Strand::Reverse);
+}
+
+#[test]
+#[should_panic(expected = "ConflictingAnnotationType")]
+fn test_add_annotation_type_conflicting_quality_spec_panics() {
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations.add_annotation_type("msp", "P".parse().unwrap());
+    annotations.add_annotation_type("msp", "Q".parse().unwrap());
+}
+
+#[test]
+fn test_strand_lives_on_annotation_not_on_type() {
+    // AnnotationType has no strand field; each Annotation does.
+    let _at = AnnotationType::new("msp", "P".parse().unwrap());
+    let a = Annotation::new(100, 50, Strand::Reverse, vec![40], None);
+    assert_eq!(a.strand, Strand::Reverse);
+}
+
+#[test]
+fn test_to_ma_string_groups_by_strand_within_type() {
+    // ctcf type with two forward + one reverse annotation must serialize
+    // as: forward section first, reverse section second, in Strand enum
+    // order. Within a section, annotations stay in insertion order.
+    let mut annotations = MolecularAnnotations::new(20);
+    annotations
+        .add_annotation_type("ctcf", "Q".parse().unwrap())
+        .add(0, 4, Strand::Forward, vec![200], None)
+        .add(10, 3, Strand::Reverse, vec![180], None)
+        .add(15, 2, Strand::Forward, vec![150], None);
+
+    assert_eq!(
+        annotations.to_ma_string(),
+        "20;ctcf+Q:1-4,16-2;ctcf-Q:11-3"
+    );
+    assert_eq!(annotations.to_aq_array(), Some(vec![200, 150, 180]));
+}
+
+#[test]
+fn test_from_tags_merges_strand_split_sections_into_one_type() {
+    // Spec example: ctcf+Q and ctcf-Q on disk → one in-memory ctcf type
+    // with two annotations of differing strand.
+    let annotations = MolecularAnnotations::from_tags(
+        "10;ctcf+Q:1-4;ctcf-Q:6-3",
+        &[],
+        Some(&[200, 180]),
+        None,
+    )
+    .expect("strand-split same-name sections must merge");
+
+    assert_eq!(annotations.annotation_types.len(), 1);
+    let ctcf = annotations.get_type("ctcf").unwrap();
+    assert_eq!(ctcf.annotations.len(), 2);
+    assert_eq!(ctcf.annotations[0].start, 0);   // 1-based 1 → 0-based 0
+    assert_eq!(ctcf.annotations[0].strand, Strand::Forward);
+    assert_eq!(ctcf.annotations[0].qualities, vec![200]);
+    assert_eq!(ctcf.annotations[1].start, 5);   // 1-based 6 → 0-based 5
+    assert_eq!(ctcf.annotations[1].strand, Strand::Reverse);
+    assert_eq!(ctcf.annotations[1].qualities, vec![180]);
+}
+
+#[test]
+fn test_from_tags_conflicting_quality_spec_for_same_name_errors() {
+    let result = MolecularAnnotations::from_tags(
+        "1000;msp+P:100-50;msp+Q:200-60",
+        &[],
+        Some(&[40, 35]),
+        None,
+    );
+    assert!(
+        matches!(result, Err(ParseError::ConflictingAnnotationType { .. })),
+        "from_tags must reject conflicting quality_spec for the same name; got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_round_trip_strand_split_preserves_on_disk_form() {
+    // Round-trip the spec example: parse → serialize → parse must yield
+    // the same in-memory state, and the serialized form must match the
+    // canonical on-disk shape.
+    let original = "10;ctcf+Q:1-4;ctcf-Q:6-3";
+    let annotations = MolecularAnnotations::from_tags(
+        original,
+        &[],
+        Some(&[200, 180]),
+        None,
+    )
+    .unwrap();
+    let (ma, _al, aq, _an) = annotations.to_tags();
+    assert_eq!(ma, original);
+    assert_eq!(aq, Some(vec![200, 180]));
 }

--- a/rust/src/tests.rs
+++ b/rust/src/tests.rs
@@ -1178,3 +1178,300 @@ fn test_round_trip_strand_split_preserves_on_disk_form() {
     assert_eq!(ma, original);
     assert_eq!(aq, Some(vec![200, 180]));
 }
+
+#[test]
+fn test_retain_on_annotation_type_directly() {
+    // The lower-level AnnotationType::retain works on the type in isolation.
+    let mut at = AnnotationType::new("msp", "P".parse().unwrap());
+    at.add(100, 50, Strand::Forward, vec![40], None);
+    at.add(200, 60, Strand::Forward, vec![35], None);
+    at.add(300, 70, Strand::Forward, vec![30], None);
+
+    at.retain(|a| a.length >= 60);
+
+    assert_eq!(at.annotations.len(), 2);
+    assert_eq!(at.annotations[0].length, 60);
+    assert_eq!(at.annotations[1].length, 70);
+}
+
+#[test]
+fn test_retain_filters_by_length() {
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None)
+        .add(200, 60, Strand::Forward, vec![35], None)
+        .add(300, 70, Strand::Forward, vec![30], None);
+
+    annotations.retain("msp", |a| a.length > 55);
+
+    let msp = annotations.get_type("msp").unwrap();
+    assert_eq!(msp.annotations.len(), 2);
+    assert_eq!(msp.annotations[0].length, 60);
+    assert_eq!(msp.annotations[1].length, 70);
+}
+
+#[test]
+fn test_retain_filters_by_quality() {
+    // Quality is per-annotation; the closure pulls qualities[0] like the
+    // fibertools `qual` filter does for single-quality specs.
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None)
+        .add(200, 60, Strand::Forward, vec![10], None)
+        .add(300, 70, Strand::Forward, vec![200], None);
+
+    annotations.retain("msp", |a| a.qualities.first().copied().unwrap_or(0) >= 40);
+
+    let msp = annotations.get_type("msp").unwrap();
+    assert_eq!(msp.annotations.len(), 2);
+    assert_eq!(msp.annotations[0].qualities, vec![40]);
+    assert_eq!(msp.annotations[1].qualities, vec![200]);
+}
+
+#[test]
+fn test_retain_with_range_predicate() {
+    // Mirrors fibertools' `len(msp)=50:100` ranged filter: [start, end).
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations
+        .add_annotation_type("msp", QualitySpec::none())
+        .add(0, 30, Strand::Forward, vec![], None)
+        .add(100, 50, Strand::Forward, vec![], None)
+        .add(200, 75, Strand::Forward, vec![], None)
+        .add(300, 100, Strand::Forward, vec![], None)
+        .add(400, 150, Strand::Forward, vec![], None);
+
+    annotations.retain("msp", |a| a.length >= 50 && a.length < 100);
+
+    let msp = annotations.get_type("msp").unwrap();
+    assert_eq!(msp.annotations.len(), 2);
+    assert_eq!(msp.annotations[0].length, 50);
+    assert_eq!(msp.annotations[1].length, 75);
+}
+
+#[test]
+fn test_retain_predicate_keeps_all() {
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None)
+        .add(200, 60, Strand::Forward, vec![35], None);
+
+    annotations.retain("msp", |_| true);
+
+    assert_eq!(annotations.get_type("msp").unwrap().annotations.len(), 2);
+}
+
+#[test]
+fn test_retain_predicate_drops_all() {
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None)
+        .add(200, 60, Strand::Forward, vec![35], None);
+
+    annotations.retain("msp", |_| false);
+
+    // Type still exists, just with zero annotations (matches the empty-type
+    // emission behavior in test_annotation_type_with_no_annotations_drops_from_emission).
+    assert_eq!(annotations.annotation_types.len(), 1);
+    assert_eq!(annotations.get_type("msp").unwrap().annotations.len(), 0);
+    assert_eq!(annotations.to_ma_string(), "1000");
+}
+
+#[test]
+fn test_retain_only_affects_named_type() {
+    // Filtering "msp" must leave "nuc" annotations untouched.
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None)
+        .add(200, 60, Strand::Forward, vec![35], None);
+    annotations
+        .add_annotation_type("nuc", QualitySpec::none())
+        .add(150, 147, Strand::Forward, vec![], None)
+        .add(350, 147, Strand::Forward, vec![], None);
+
+    annotations.retain("msp", |a| a.length >= 60);
+
+    assert_eq!(annotations.get_type("msp").unwrap().annotations.len(), 1);
+    // nuc untouched.
+    assert_eq!(annotations.get_type("nuc").unwrap().annotations.len(), 2);
+}
+
+#[test]
+fn test_retain_unknown_type_is_noop() {
+    // Filtering a non-existent type name must not panic or modify anything.
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(100, 50, Strand::Forward, vec![40], None);
+
+    annotations.retain("does_not_exist", |_| false);
+
+    assert_eq!(annotations.get_type("msp").unwrap().annotations.len(), 1);
+    assert!(annotations.get_type("does_not_exist").is_none());
+}
+
+#[test]
+fn test_retain_on_empty_type_is_noop() {
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations.add_annotation_type("empty", QualitySpec::none());
+
+    annotations.retain("empty", |_| false);
+
+    assert_eq!(annotations.annotation_types.len(), 1);
+    assert_eq!(annotations.get_type("empty").unwrap().annotations.len(), 0);
+}
+
+#[test]
+fn test_retain_preserves_insertion_order() {
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations
+        .add_annotation_type("msp", QualitySpec::none())
+        .add(100, 10, Strand::Forward, vec![], None)
+        .add(200, 50, Strand::Forward, vec![], None)
+        .add(300, 20, Strand::Forward, vec![], None)
+        .add(400, 60, Strand::Forward, vec![], None)
+        .add(500, 30, Strand::Forward, vec![], None);
+
+    annotations.retain("msp", |a| a.length >= 30);
+
+    let msp = annotations.get_type("msp").unwrap();
+    assert_eq!(msp.annotations.len(), 3);
+    assert_eq!(msp.annotations[0].start, 200);
+    assert_eq!(msp.annotations[1].start, 400);
+    assert_eq!(msp.annotations[2].start, 500);
+}
+
+#[test]
+fn test_retain_preserves_per_annotation_strand() {
+    // Strand is per-annotation; retain must keep the matched annotations'
+    // strand intact, including a mix of strands within one type.
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations
+        .add_annotation_type("ctcf", "Q".parse().unwrap())
+        .add(0, 4, Strand::Forward, vec![200], None)
+        .add(10, 30, Strand::Reverse, vec![180], None)
+        .add(50, 5, Strand::Forward, vec![150], None);
+
+    // Keep only annotations whose length >= 5.
+    annotations.retain("ctcf", |a| a.length >= 5);
+
+    let ctcf = annotations.get_type("ctcf").unwrap();
+    assert_eq!(ctcf.annotations.len(), 2);
+    assert_eq!(ctcf.annotations[0].strand, Strand::Reverse);
+    assert_eq!(ctcf.annotations[0].length, 30);
+    assert_eq!(ctcf.annotations[1].strand, Strand::Forward);
+    assert_eq!(ctcf.annotations[1].length, 5);
+}
+
+#[test]
+fn test_retain_preserves_multi_quality_values() {
+    let mut annotations = MolecularAnnotations::new(1000);
+    let pq = QualitySpec::from_str("PQ").unwrap();
+    annotations
+        .add_annotation_type("msp", pq)
+        .add(100, 50, Strand::Forward, vec![40, 255], None)
+        .add(200, 60, Strand::Forward, vec![10, 100], None)
+        .add(300, 70, Strand::Forward, vec![30, 200], None);
+
+    // Filter on the linear (second) quality value.
+    annotations.retain("msp", |a| a.qualities[1] >= 200);
+
+    let msp = annotations.get_type("msp").unwrap();
+    assert_eq!(msp.annotations.len(), 2);
+    assert_eq!(msp.annotations[0].qualities, vec![40, 255]);
+    assert_eq!(msp.annotations[1].qualities, vec![30, 200]);
+}
+
+#[test]
+fn test_retain_updates_serialization() {
+    // After retain, the on-disk MA/AL/AQ tags should reflect only the
+    // surviving annotations and respect strand-grouped section order.
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations.set_encoding(Encoding::Inline);
+    annotations
+        .add_annotation_type("msp", "P".parse().unwrap())
+        .add(99, 50, Strand::Forward, vec![40], None)    // MA tag pos 100
+        .add(199, 60, Strand::Forward, vec![35], None)   // MA tag pos 200
+        .add(299, 70, Strand::Forward, vec![30], None);  // MA tag pos 300
+
+    annotations.retain("msp", |a| a.length >= 60);
+
+    assert_eq!(annotations.to_ma_string(), "1000;msp+P:200-60,300-70");
+    assert_eq!(annotations.to_aq_array(), Some(vec![35, 30]));
+}
+
+#[test]
+fn test_retain_updates_total_annotation_count() {
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations
+        .add_annotation_type("msp", QualitySpec::none())
+        .add(100, 50, Strand::Forward, vec![], None)
+        .add(200, 60, Strand::Forward, vec![], None);
+    annotations
+        .add_annotation_type("nuc", QualitySpec::none())
+        .add(150, 147, Strand::Forward, vec![], None);
+
+    assert_eq!(annotations.total_annotation_count(), 3);
+
+    annotations.retain("msp", |a| a.length >= 60);
+
+    assert_eq!(annotations.total_annotation_count(), 2);
+}
+
+#[test]
+fn test_retain_with_mutable_state_in_closure() {
+    // FnMut: the closure may hold mutable state (e.g. a counter / cap on
+    // how many to keep). Useful for take-N-style filters.
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations
+        .add_annotation_type("msp", QualitySpec::none())
+        .add(100, 50, Strand::Forward, vec![], None)
+        .add(200, 60, Strand::Forward, vec![], None)
+        .add(300, 70, Strand::Forward, vec![], None)
+        .add(400, 80, Strand::Forward, vec![], None);
+
+    let mut kept = 0;
+    annotations.retain("msp", |_| {
+        if kept < 2 {
+            kept += 1;
+            true
+        } else {
+            false
+        }
+    });
+
+    let msp = annotations.get_type("msp").unwrap();
+    assert_eq!(msp.annotations.len(), 2);
+    assert_eq!(msp.annotations[0].start, 100);
+    assert_eq!(msp.annotations[1].start, 200);
+}
+
+#[test]
+fn test_retain_with_reference_coords_via_aligned_blocks() {
+    // A more realistic use case: filter by reference-coord predicate by
+    // pre-computing the lift inside the closure.
+    let mut annotations = MolecularAnnotations::new(1000);
+    annotations
+        .add_annotation_type("msp", QualitySpec::none())
+        .add(50, 20, Strand::Forward, vec![], None)    // ref [1050, 1070)
+        .add(200, 30, Strand::Forward, vec![], None)   // ref [1200, 1230)
+        .add(450, 40, Strand::Forward, vec![], None);  // ref [1450, 1490)
+
+    annotations.set_aligned_blocks(vec![([0, 500], [1000, 1500])], false);
+
+    // Need to snapshot the blocks out before borrowing mutably for retain.
+    let blocks = annotations.aligned_blocks().cloned().unwrap();
+    annotations.retain("msp", |a| {
+        let (rs, _) = a.ref_coords(&blocks);
+        rs.map(|s| s >= 1200).unwrap_or(false)
+    });
+
+    let msp = annotations.get_type("msp").unwrap();
+    assert_eq!(msp.annotations.len(), 2);
+    assert_eq!(msp.annotations[0].start, 200);
+    assert_eq!(msp.annotations[1].start, 450);
+}

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -51,6 +51,51 @@ pub struct AnnotationInfo<'a> {
     pub name: Option<&'a str>,
 }
 
+/// An annotation with coordinates projected into a shifted coordinate frame.
+///
+/// Returned by [`MolecularAnnotations::project_query`] and
+/// [`MolecularAnnotations::project_reference`]. Both `start` and `end` are
+/// 0-based half-open `[start, end)` intervals, shifted so the projection
+/// anchor sits at 0. Either bound may be negative.
+///
+/// The frame the coordinates live in is determined by which `project_*`
+/// method produced the value — `ProjectedAnnotation` itself carries no
+/// frame metadata, on the assumption that the caller knows what they
+/// asked for. The same goes for the anchor and the flip flag.
+///
+/// Projected annotations are a one-way view intended for output and
+/// downstream analysis. They cannot be serialized back into MA tags
+/// (the on-disk format requires non-negative positions) and do not
+/// round-trip through [`MolecularAnnotations`].
+///
+/// Fields borrow from the source [`MolecularAnnotations`]; the projected
+/// view lives only as long as the container it came from.
+///
+/// # Example
+/// ```
+/// use molecular_annotation::{MolecularAnnotations, Strand, QualitySpec};
+///
+/// let mut annotations = MolecularAnnotations::new(1000);
+/// annotations
+///     .add_annotation_type("msp", "P".parse().unwrap())
+///     .add(100, 50, Strand::Forward, vec![40], None);  // [100, 150)
+///
+/// // Project around query position 120: annotation lands at [-20, 30).
+/// let projected: Vec<_> = annotations.project_query(120, false).collect();
+/// assert_eq!(projected[0].start, -20);
+/// assert_eq!(projected[0].end, 30);
+/// ```
+#[derive(Debug, Clone)]
+pub struct ProjectedAnnotation<'a> {
+    pub type_name: &'a str,
+    pub start: i64,
+    pub end: i64,
+    pub strand: Strand,
+    pub qualities: &'a [u8],
+    pub name: Option<&'a str>,
+}
+
+
 /// Error types for parsing molecular annotations
 #[derive(Debug, Clone, PartialEq)]
 pub enum ParseError {

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -394,4 +394,10 @@ impl AnnotationType {
         self.annotations.push(Annotation::new(start, length, strand, qualities, name));
         self
     }
+    /// Drop annotations for which `predicate` returns false.
+    pub fn retain<F: FnMut(&Annotation) -> bool>(&mut self, predicate: F) {
+        self.annotations.retain(predicate);
+    }
 }
+
+

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -271,13 +271,17 @@ impl FromStr for QualitySpec {
 
 /// A single molecular annotation.
 ///
-/// All coordinates are 0-based half-open [start, end).
+/// All coordinates are 0-based half-open [start, end). Strand is a property
+/// of each annotation, not of its containing [`AnnotationType`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct Annotation {
-    /// 0-based start position (inclusive)
+    /// 0-based start position (inclusive), in original molecular orientation
     pub start: u32,
     /// Length in base pairs (end = start + length)
     pub length: u32,
+    /// Strand of this annotation. Describes the biology of the feature, not
+    /// the alignment orientation.
+    pub strand: Strand,
     /// Quality scores (one per quality spec character, empty if type has no quality)
     pub qualities: Vec<u8>,
     /// Optional name/label for this annotation
@@ -292,14 +296,14 @@ impl Annotation {
     /// # Panics
     /// Panics in debug mode if:
     /// - `start + length` would overflow u32
-    pub fn new(start: u32, length: u32, qualities: Vec<u8>, name: Option<String>) -> Self {
+    pub fn new(start: u32, length: u32, strand: Strand, qualities: Vec<u8>, name: Option<String>) -> Self {
         debug_assert!(
             start.checked_add(length).is_some(),
             "Annotation coordinate overflow: start={} + length={} exceeds u32",
             start,
             length
         );
-        Self { start, length, qualities, name }
+        Self { start, length, strand, qualities, name }
     }
 
     /// Returns the end position (0-based, exclusive).
@@ -341,13 +345,17 @@ impl Annotation {
     }
 }
 
-/// A group of annotations of the same type
+/// A group of annotations of the same type.
+///
+/// Annotation type identity within a [`MolecularAnnotations`](crate::MolecularAnnotations)
+/// is keyed on `name` alone. Strand is a property of each [`Annotation`];
+/// one type may contain annotations on different strands. `quality_spec` is
+/// a per-type property but is not part of the identity — adding the same
+/// `name` twice with conflicting `quality_spec` is an error.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AnnotationType {
     /// Name of the annotation type (e.g., "msp", "nuc", "fire")
     pub name: String,
-    /// Strand orientation
-    pub strand: Strand,
     /// Quality specification (number and scaling of quality values per annotation)
     pub quality_spec: QualitySpec,
     /// Individual annotations of this type
@@ -355,19 +363,20 @@ pub struct AnnotationType {
 }
 
 impl AnnotationType {
-    /// Create a new annotation type
-    pub fn new(name: impl Into<String>, strand: Strand, quality_spec: QualitySpec) -> Self {
+    /// Create a new annotation type.
+    pub fn new(name: impl Into<String>, quality_spec: QualitySpec) -> Self {
         Self {
             name: name.into(),
-            strand,
             quality_spec,
             annotations: Vec::new(),
         }
     }
 
-    /// Returns the type signature string (e.g., "msp+P", "nuc-", "fire.PQ")
-    pub fn type_signature(&self) -> String {
-        format!("{}{}{}", self.name, self.strand, self.quality_spec)
+    /// Returns the on-disk section signature string for a given strand
+    /// (e.g., `"msp+P"`, `"nuc-"`, `"fire.PQ"`). Used during serialization
+    /// when annotations are grouped by `(name, strand)` into MA sections.
+    pub fn type_signature(&self, strand: Strand) -> String {
+        format!("{}{}{}", self.name, strand, self.quality_spec)
     }
 
     /// Add an annotation to this type.
@@ -378,10 +387,11 @@ impl AnnotationType {
         &mut self,
         start: u32,
         length: u32,
+        strand: Strand,
         qualities: Vec<u8>,
         name: Option<String>,
     ) -> &mut Self {
-        self.annotations.push(Annotation::new(start, length, qualities, name));
+        self.annotations.push(Annotation::new(start, length, strand, qualities, name));
         self
     }
 }


### PR DESCRIPTION
This PR makes 1 major change to the library: moving strand from the AnnotationType to Annotation (f062c750b295c9d2401ee2427bba98ff2f629197). We also clarify here that **Annotation type identity is keyed on name only** (251fa1148249cd18e3fe3c406127bffeea75fe3c)

Other changes here are purely additive and not related to the specification.  These are features to the library for working with Molecular Annotations, such as filtering and projecting annotations.